### PR TITLE
Fixes inability to click the games list items on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "2.0.0",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/cores/info/platform/index.tsx
+++ b/src/components/cores/info/platform/index.tsx
@@ -6,7 +6,7 @@ import { Link } from "../../../link"
 
 import "./index.css"
 
-const HARD_TO_FIND_THINGS = ["Genesis", "Dominos", "Green Beret"]
+const HARD_TO_FIND_THINGS = ["Asteroids", "Genesis", "Dominos", "Green Beret"]
 
 type CorePlatformInfoProps = {
   platformId: PlatformId

--- a/src/components/cores/info/sponsorLinks/index.tsx
+++ b/src/components/cores/info/sponsorLinks/index.tsx
@@ -13,15 +13,13 @@ export const SponsorLinks = ({ links }: SponsorLinkProps) => {
 
   return (
     <div className="sponsor-links">
-      {sponsorTypes.map((sponsorKey) => (
-        <Link
-          className="sponsor-links__link"
-          key={sponsorKey}
-          href={links[sponsorKey]}
-        >
-          {links[sponsorKey]}
-        </Link>
-      ))}
+      {sponsorTypes.flatMap((sponsorKey) =>
+        links[sponsorKey].map((link) => (
+          <Link className="sponsor-links__link" key={link} href={link}>
+            {link}
+          </Link>
+        ))
+      )}
     </div>
   )
 }

--- a/src/components/link/index.tsx
+++ b/src/components/link/index.tsx
@@ -14,7 +14,7 @@ export const Link = ({ children, className, href }: LinkProps) => {
     <span
       className={`link ${className ?? ""}`}
       onClick={() => {
-        if (href) open(window.encodeURI(href))
+        if (href) open(href)
       }}
     >
       {children}

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,7 +113,7 @@ export type InventoryItem = {
   release?: InventoryItemRelease
   prerelease?: InventoryItemRelease
   sponsor?: {
-    [k: string]: string
+    [k: string]: [string]
   }
 }
 


### PR DESCRIPTION
- Should fix https://github.com/neil-morrison44/pocket-sync/issues/5
- Turns out I'd read the `sponsor` bit of the inventory JSON wrong & implemented a workaround which was breaking things