### PR TITLE
Fix missing platform images

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.2.0"
+    "version": "1.2.1"
   },
   "tauri": {
     "allowlist": {

--- a/src/recoil/selectors.ts
+++ b/src/recoil/selectors.ts
@@ -236,8 +236,18 @@ export const ImageBinSrcSelectorFamily = selectorFamily<
   get:
     ({ path, width, height }) =>
     async ({ get }) => {
-      console.log({ path, width, height })
       get(fileSystemInvalidationAtom)
+
+      const exists = await invokeFileExists(path)
+
+      if (!exists) {
+        // https://www.analogue.co/developer/docs/platform-metadata#platform-image
+        // A platform _may_ have a graphic associated with it.
+
+        const emptyBuffer = new Uint8Array(width * height * 2)
+        return renderBinImage(emptyBuffer, width, height, true)
+      }
+
       const response = await invokeReadBinaryFile(path)
 
       return await new Promise<string>((resolve) => {


### PR DESCRIPTION
- Platform images are more optional than I thought (see JOTEGO double dragon cores)
- Technically _platforms_ are optional too, but no one core's had a platform yet so I'll worry about that later