### PR TITLE
Enables browsing & bulk deleting save states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "pocket-sync",
-  "version": "1.0.2",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pocket-sync",
-      "version": "1.0.2",
+      "version": "1.2.1",
       "dependencies": {
         "@react-three/drei": "^9.40.0",
         "@react-three/fiber": "^8.9.1",
         "@tauri-apps/api": "^1.2.0",
         "@types/three": "^0.146.0",
+        "date-fns": "^2.29.3",
         "fast-fuzzy": "^1.12.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -1213,6 +1214,18 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debounce": {
       "version": "1.2.1",
@@ -4381,6 +4394,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
       "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+    },
+    "date-fns": {
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+      "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
     },
     "debounce": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-three/fiber": "^8.9.1",
     "@tauri-apps/api": "^1.2.0",
     "@types/three": "^0.146.0",
+    "date-fns": "^2.29.3",
     "fast-fuzzy": "^1.12.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -320,6 +320,21 @@ async fn create_folder_if_missing(path: &str) -> Result<bool, ()> {
     Ok(false)
 }
 
+#[tauri::command(async)]
+async fn delete_files(
+    paths: Vec<&str>,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<bool, ()> {
+    let pocket_path = state.0.read().await;
+    for path in paths {
+        let file_path = pocket_path.join(path);
+        if file_path.exists() {
+            fs::remove_file(file_path).unwrap()
+        }
+    }
+    Ok(true)
+}
+
 fn main() {
     tauri::Builder::default()
         .manage(PocketSyncState(Default::default()))
@@ -338,7 +353,8 @@ fn main() {
             list_saves_in_zip,
             list_saves_on_pocket,
             restore_save,
-            create_folder_if_missing
+            create_folder_if_missing,
+            delete_files
         ])
         .setup(|app| start_threads(&app))
         .run(tauri::generate_context!())

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -6,6 +6,7 @@ import { Games } from "../games"
 import { Loader } from "../loader"
 import { Platforms } from "../platforms"
 import { Saves } from "../saves"
+import { SaveStates } from "../saveStates"
 import { Screenshots } from "../screenshots"
 import { Settings } from "../settings"
 import { ZipInstall } from "../zipInstall"
@@ -18,6 +19,7 @@ export const Layout = () => {
     "Cores",
     "Screenshots",
     "Saves",
+    "Save States",
     "Platforms",
     "Settings",
   ] as const
@@ -48,6 +50,7 @@ export const Layout = () => {
           {viewName === "Settings" && <Settings />}
           {viewName === "Games" && <Games />}
           {viewName === "Saves" && <Saves />}
+          {viewName === "Save States" && <SaveStates />}
           {viewName === "Platforms" && <Platforms />}
         </Suspense>
       </div>

--- a/src/components/platforms/hooks/useUpdatePlatform.ts
+++ b/src/components/platforms/hooks/useUpdatePlatform.ts
@@ -1,9 +1,7 @@
 import { useCallback } from "react"
-import { useRecoilValue, useSetRecoilState } from "recoil"
-import {
-  fileSystemInvalidationAtom,
-  pocketPathAtom,
-} from "../../../recoil/atoms"
+import { useRecoilValue } from "recoil"
+import { useInvalidateFileSystem } from "../../../hooks/invalidation"
+import { pocketPathAtom } from "../../../recoil/atoms"
 import { PlatformInfoSelectorFamily } from "../../../recoil/platforms/selectors"
 import { PlatformId, PlatformInfoJSON } from "../../../types"
 import { invokeSaveFile } from "../../../utils/invokes"
@@ -13,7 +11,7 @@ type InnerPlatform = PlatformInfoJSON["platform"]
 export const useUpdatePlatformValue = (id: PlatformId) => {
   const platformInfo = useRecoilValue(PlatformInfoSelectorFamily(id))
   const pocketPath = useRecoilValue(pocketPathAtom)
-  const invalidateFS = useSetRecoilState(fileSystemInvalidationAtom)
+  const invalidateFS = useInvalidateFileSystem()
 
   return useCallback(
     async <T extends keyof InnerPlatform>(key: T, value: InnerPlatform[T]) => {
@@ -30,7 +28,7 @@ export const useUpdatePlatformValue = (id: PlatformId) => {
         encoder.encode(JSON.stringify(newPlatform, null, 2))
       )
 
-      setTimeout(() => invalidateFS(Date.now()), 500)
+      setTimeout(() => invalidateFS(), 500)
     },
     [platformInfo]
   )

--- a/src/components/platforms/info/imageEditor/index.tsx
+++ b/src/components/platforms/info/imageEditor/index.tsx
@@ -1,12 +1,9 @@
 import { useCallback, useRef, useState } from "react"
-import { useRecoilValue, useSetRecoilState } from "recoil"
+import { useRecoilValue } from "recoil"
 import { ImageBinSrcSelectorFamily } from "../../../../recoil/selectors"
 import { Modal } from "../../../modal"
 import { invokeSaveFile } from "../../../../utils/invokes"
-import {
-  fileSystemInvalidationAtom,
-  pocketPathAtom,
-} from "../../../../recoil/atoms"
+import { pocketPathAtom } from "../../../../recoil/atoms"
 import { ImageInfo } from "./types"
 import {
   renderStamps,
@@ -18,6 +15,7 @@ import {
 } from "./hooks/stamps"
 
 import "./index.css"
+import { useInvalidateFileSystem } from "../../../../hooks/invalidation"
 
 type ImageEditorProps = {
   onClose: () => void
@@ -36,7 +34,7 @@ export const ImageEditor = ({
     ImageBinSrcSelectorFamily({ path, width, height })
   )
   const pocketPath = useRecoilValue(pocketPathAtom)
-  const invalidateFS = useSetRecoilState(fileSystemInvalidationAtom)
+  const invalidateFS = useInvalidateFileSystem()
   const [selectedStampIndex, setSelectedStampIndex] = useState(0)
   const [imageStamps, setImageStamps] = useState<ImageInfo[]>([])
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -70,7 +68,7 @@ export const ImageEditor = ({
     }
 
     await invokeSaveFile(`${pocketPath}/${path}`, buffer)
-    invalidateFS(Date.now())
+    invalidateFS()
     onClose()
   }, [width, height])
 

--- a/src/components/saveStates/index.css
+++ b/src/components/saveStates/index.css
@@ -1,0 +1,72 @@
+.save-states{
+  --controls-height: 55px;
+}
+
+
+.save-states__items{
+  display: flex;
+  gap: 8px;
+  padding: 10px;
+  flex-wrap: wrap;
+}
+
+.save-states__core-header{
+  background-color: var(--hover-colour);
+  padding: 10px 20px;
+
+  position: sticky;
+  top: var(--controls-height);
+
+  display: flex;
+  justify-content: space-between;
+}
+
+.save-states__item{
+  --flex-size: 50%;
+  display: flex;
+  align-items: center;
+  background-color: var(--info-colour);
+  padding: 10px;
+  box-sizing: border-box;
+  gap: 20px;
+  flex-basis: calc(var(--flex-size) - 4px);
+  cursor: pointer;
+  border: 2px solid transparent;
+
+  &:hover{
+    transform: scale(1.05);
+  }
+
+  @media (max-width: 800px) {
+    --flex-size: 100%;
+  }
+
+  @media (min-width: 1000px) {
+    --flex-size: 33%;
+  }
+
+  @media (min-width: 1200px) {
+    --flex-size: 25%;
+  }
+}
+
+.save-states__item--selected {
+  border-color: #396cd8;
+}
+
+.save-states__item-info{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.save-states__item-name{
+  font-weight: bold;
+}
+
+.save-states__item-image{
+  flex-shrink: 0;
+  width: 123px;
+  height: auto;
+  aspect-ratio: 160 / 144;
+}

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -1,0 +1,23 @@
+import { Suspense } from "react"
+import { useRecoilValue } from "recoil"
+import { AllSaveStatesSelector } from "../../recoil/saveStates/selectors"
+import { SaveStateItem } from "./item"
+import { Loader } from "../loader"
+
+export const SaveStates = () => {
+  const allSaveStates = useRecoilValue(AllSaveStatesSelector)
+
+  return (
+    <div>
+      {"Save States"}
+
+      <div>
+        {allSaveStates.map((p) => (
+          <Suspense fallback={<Loader />} key={p}>
+            <SaveStateItem path={p} />
+          </Suspense>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -1,23 +1,125 @@
-import { Suspense } from "react"
+import { Fragment, Suspense, useCallback, useMemo, useState } from "react"
 import { useRecoilValue } from "recoil"
 import { AllSaveStatesSelector } from "../../recoil/saveStates/selectors"
 import { SaveStateItem } from "./item"
 import { Loader } from "../loader"
 
+import "./index.css"
+import { CoreInfoSelectorFamily } from "../../recoil/selectors"
+import { Controls } from "../controls"
+import { SearchContextProvider } from "../search/context"
+import { confirm } from "@tauri-apps/api/dialog"
+import { invokeDeleteFiles } from "../../utils/invokes"
+import { useInvalidateFileSystem } from "../../hooks/invalidation"
+
 export const SaveStates = () => {
+  const invalidateFS = useInvalidateFileSystem()
   const allSaveStates = useRecoilValue(AllSaveStatesSelector)
+  const [selectedStates, setSelectedStates] = useState<string[]>([])
+  const [searchQuery, setSearchQuery] = useState("")
+
+  const groupByCore = useMemo(
+    () =>
+      allSaveStates.reduce((g, p) => {
+        const coreName = p.substring(0, p.indexOf("/"))
+
+        const existing = g[coreName]
+        if (existing) {
+          existing.push(p)
+        } else {
+          g[coreName] = [p]
+        }
+
+        return g
+      }, {} as { [k: string]: string[] }),
+    [allSaveStates]
+  )
+
+  const deleteSelected = useCallback(async () => {
+    const plural = selectedStates.length > 1
+    const okToDelete = await confirm(
+      `Are you sure you want to delete ${selectedStates.length} save state${
+        plural ? "s" : ""
+      }?`
+    )
+    if (!okToDelete) return
+
+    await invokeDeleteFiles(
+      selectedStates.map((s) => `Memories/Save States/${s}`)
+    )
+    setSelectedStates([])
+    invalidateFS()
+  }, [selectedStates, setSelectedStates])
 
   return (
-    <div>
-      {"Save States"}
-
+    <div className="save-states">
+      <Controls
+        controls={[
+          {
+            type: "search",
+            text: "Search",
+            value: searchQuery,
+            onChange: (v) => setSearchQuery(v),
+          },
+          selectedStates.length === 0
+            ? undefined
+            : {
+                type: "button",
+                text: `Clear Selection (${selectedStates.length})`,
+                onClick: () => setSelectedStates([]),
+              },
+          selectedStates.length === 0
+            ? undefined
+            : {
+                type: "button",
+                text: `Delete Selected (${selectedStates.length})`,
+                onClick: deleteSelected,
+              },
+        ]}
+      />
       <div>
-        {allSaveStates.map((p) => (
-          <Suspense fallback={<Loader />} key={p}>
-            <SaveStateItem path={p} />
-          </Suspense>
-        ))}
+        <SearchContextProvider query={searchQuery}>
+          {Object.entries(groupByCore).map(([coreName, saveStates]) => (
+            <Fragment key={coreName}>
+              <CoreNameHeader coreName={coreName} count={saveStates.length} />
+              <div className="save-states__items">
+                {saveStates.map((p) => (
+                  <Suspense fallback={<Loader />} key={p}>
+                    <SaveStateItem
+                      path={p}
+                      selected={selectedStates.includes(p)}
+                      onClick={() =>
+                        setSelectedStates((s) => {
+                          if (s.includes(p)) return s.filter((os) => os !== p)
+                          return [...s, p]
+                        })
+                      }
+                    />
+                  </Suspense>
+                ))}
+              </div>
+            </Fragment>
+          ))}
+        </SearchContextProvider>
       </div>
+    </div>
+  )
+}
+
+const CoreNameHeader = ({
+  coreName,
+  count,
+}: {
+  coreName: string
+  count: number
+}) => {
+  const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
+
+  return (
+    <div className="save-states__core-header">
+      {`${coreInfo.core.metadata.shortname}`}
+
+      <div className="save-states__core-header-count">{`( ${count} / 128 )`}</div>
     </div>
   )
 }

--- a/src/components/saveStates/item.tsx
+++ b/src/components/saveStates/item.tsx
@@ -1,68 +1,72 @@
-import React from "react"
-import { SaveStateBinarySelectorFamily } from "../../recoil/saveStates/selectors"
+import React, { useMemo } from "react"
+import {
+  SaveStateBinarySelectorFamily,
+  SaveStateImageSelectorFamily,
+  SaveStateMetadataSelectorFamily,
+} from "../../recoil/saveStates/selectors"
 import { useRecoilValue } from "recoil"
+import { getBinaryMetadata } from "../../utils/getBinaryMetadata"
+import { parse } from "date-fns"
+import { SearchContextSelfHidingConsumer } from "../search/context"
 
-const decodeThumbnail = (file: Uint8Array) => {
-  const IPAyHeader = Array.from("IPAy").map((c) => c.charCodeAt(0))
-  let foundIndex = 0
-
-  fileloop: for (
-    let index = 0;
-    index < file.length - IPAyHeader.length;
-    index++
-  ) {
-    const element = file[index]
-    for (let headerIndex = 0; headerIndex < IPAyHeader.length; headerIndex++) {
-      const element = IPAyHeader[headerIndex]
-      if (file[index + headerIndex] !== IPAyHeader[headerIndex]) {
-        continue fileloop
-      }
-      foundIndex = index
-    }
-  }
-  const imagePayloadSlice = file.slice(file.byteLength - 52756)
-
-  console.log({ imagePayloadSlice })
-
-  const canvas = document.createElement("canvas")
-  canvas.width = 122
-  canvas.height = 145
-
-  const context = canvas.getContext("2d") as CanvasRenderingContext2D
-
-  let dataIndex = 0
-
-  const imageDataSwap = context.getImageData(0, 0, 1, 1)
-  imageDataSwap.data[3] = 255
-
-  for (let x = 0; x < canvas.width - 1; x++) {
-    for (let y = 0; y < canvas.height; y++) {
-      const indexOffset = y % 4
-      imageDataSwap.data[2] = imagePayloadSlice[indexOffset + dataIndex++]
-      imageDataSwap.data[1] = imagePayloadSlice[indexOffset + dataIndex++]
-      imageDataSwap.data[0] = imagePayloadSlice[indexOffset + dataIndex++]
-      context.putImageData(imageDataSwap, canvas.width - x, y)
-    }
-    dataIndex++
-  }
-
-  return canvas.toDataURL()
+type SaveStateItemProps = {
+  path: string
+  selected: boolean
+  onClick: () => void
 }
 
-export const SaveStateItem = ({ path }: { path: string }) => {
-  const file = useRecoilValue(SaveStateBinarySelectorFamily(path))
+export const SaveStateItem = ({
+  path,
+  selected,
+  onClick,
+}: SaveStateItemProps) => {
+  const metadata = useRecoilValue(SaveStateMetadataSelectorFamily(path))
+  const imageSrc = useRecoilValue(SaveStateImageSelectorFamily(path))
+  const date = useSaveStateDate(path)
 
-  const src = decodeThumbnail(file)
+  const gameName = useMemo(() => {
+    const { game } = metadata
+    const filetypeIndex = game.lastIndexOf(".")
+    return game.substring(0, filetypeIndex)
+  }, [metadata.game])
 
   return (
-    <div>
-      {path}
+    <SearchContextSelfHidingConsumer
+      fields={[metadata.game, metadata.platform]}
+    >
+      <div
+        className={`save-states__item save-states__item--${
+          selected ? "selected" : "unselected"
+        }`}
+        onClick={onClick}
+      >
+        <img className="save-states__item-image" src={imageSrc}></img>
 
-      <img
-        src={src}
-        // width={"200%"}
-        style={{ imageRendering: "pixelated" }}
-      ></img>
-    </div>
+        <div className="save-states__item-info">
+          <div className="save-states__item-name">{gameName}</div>
+          {date && (
+            <div className="save-states__item--date">
+              <div>{date.toLocaleDateString()}</div>
+              <div>{date.toLocaleTimeString()}</div>
+            </div>
+          )}
+        </div>
+      </div>
+    </SearchContextSelfHidingConsumer>
   )
+}
+
+const useSaveStateDate = (path: string) => {
+  return useMemo(() => {
+    const dateRegex = /\/(?<year>\d{8})_(?<time>\d{6})_/g
+    const match = dateRegex.exec(path)
+    if (!match?.groups) return null
+
+    const date = parse(
+      `${match.groups.year}-${match.groups.time}`,
+      "yyyyMMdd-HHmmSS",
+      new Date()
+    )
+    return date
+  }, [path])
 }

--- a/src/components/saveStates/item.tsx
+++ b/src/components/saveStates/item.tsx
@@ -1,0 +1,68 @@
+import React from "react"
+import { SaveStateBinarySelectorFamily } from "../../recoil/saveStates/selectors"
+import { useRecoilValue } from "recoil"
+
+const decodeThumbnail = (file: Uint8Array) => {
+  const IPAyHeader = Array.from("IPAy").map((c) => c.charCodeAt(0))
+  let foundIndex = 0
+
+  fileloop: for (
+    let index = 0;
+    index < file.length - IPAyHeader.length;
+    index++
+  ) {
+    const element = file[index]
+    for (let headerIndex = 0; headerIndex < IPAyHeader.length; headerIndex++) {
+      const element = IPAyHeader[headerIndex]
+      if (file[index + headerIndex] !== IPAyHeader[headerIndex]) {
+        continue fileloop
+      }
+      foundIndex = index
+    }
+  }
+  const imagePayloadSlice = file.slice(file.byteLength - 52756)
+
+  console.log({ imagePayloadSlice })
+
+  const canvas = document.createElement("canvas")
+  canvas.width = 122
+  canvas.height = 145
+
+  const context = canvas.getContext("2d") as CanvasRenderingContext2D
+
+  let dataIndex = 0
+
+  const imageDataSwap = context.getImageData(0, 0, 1, 1)
+  imageDataSwap.data[3] = 255
+
+  for (let x = 0; x < canvas.width - 1; x++) {
+    for (let y = 0; y < canvas.height; y++) {
+      const indexOffset = y % 4
+      imageDataSwap.data[2] = imagePayloadSlice[indexOffset + dataIndex++]
+      imageDataSwap.data[1] = imagePayloadSlice[indexOffset + dataIndex++]
+      imageDataSwap.data[0] = imagePayloadSlice[indexOffset + dataIndex++]
+      context.putImageData(imageDataSwap, canvas.width - x, y)
+    }
+    dataIndex++
+  }
+
+  return canvas.toDataURL()
+}
+
+export const SaveStateItem = ({ path }: { path: string }) => {
+  const file = useRecoilValue(SaveStateBinarySelectorFamily(path))
+
+  const src = decodeThumbnail(file)
+
+  return (
+    <div>
+      {path}
+
+      <img
+        src={src}
+        // width={"200%"}
+        style={{ imageRendering: "pixelated" }}
+      ></img>
+    </div>
+  )
+}

--- a/src/components/saves/hooks/useBuildsaveZip.ts
+++ b/src/components/saves/hooks/useBuildsaveZip.ts
@@ -1,19 +1,19 @@
 import { useCallback, useState } from "react"
-import { useRecoilValue, useSetRecoilState } from "recoil"
-import { fileSystemInvalidationAtom } from "../../../recoil/atoms"
+import { useRecoilValue } from "recoil"
+import { useInvalidateFileSystem } from "../../../hooks/invalidation"
 import { AllSavesSelector } from "../../../recoil/saves/selectors"
 import { invokeBackupSaves } from "../../../utils/invokes"
 
 export const useBuildSaveZip = () => {
   const allSaves = useRecoilValue(AllSavesSelector)
-  const invalidateFS = useSetRecoilState(fileSystemInvalidationAtom)
+  const invalidateFS = useInvalidateFileSystem()
   const [backupInProgress, setBackupInProgress] = useState(false)
 
   const backup = useCallback(
     async (savePath: string, maxCount: number) => {
       setBackupInProgress(true)
       await invokeBackupSaves(allSaves, savePath, maxCount)
-      invalidateFS(Date.now())
+      invalidateFS()
       setBackupInProgress(false)
     },
     [allSaves]

--- a/src/components/zipInstall/hooks.ts
+++ b/src/components/zipInstall/hooks.ts
@@ -1,7 +1,6 @@
 import { emit, listen } from "@tauri-apps/api/event"
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { useSetRecoilState } from "recoil"
-import { fileSystemInvalidationAtom } from "../../recoil/atoms"
+import { useInvalidateFileSystem } from "../../hooks/invalidation"
 import { filterKnownBadFiles } from "../../utils/filterFiles"
 import { FileTreeNode, InstallZipEventPayload } from "./types"
 
@@ -9,7 +8,7 @@ export const useListenForZipInstall = () => {
   const [installState, setInstallState] =
     useState<null | InstallZipEventPayload>(null)
 
-  const updateFSInvalidationAtom = useSetRecoilState(fileSystemInvalidationAtom)
+  const invalidateFS = useInvalidateFileSystem()
 
   useEffect(() => {
     const unlisten = listen<InstallZipEventPayload>(
@@ -26,7 +25,7 @@ export const useListenForZipInstall = () => {
       "install-zip-finished",
       ({ payload }) => {
         setInstallState(null)
-        updateFSInvalidationAtom(Date.now())
+        invalidateFS()
       }
     )
     return () => {

--- a/src/hooks/invalidation.ts
+++ b/src/hooks/invalidation.ts
@@ -1,0 +1,43 @@
+import { useRecoilCallback } from "recoil"
+import {
+  configInvalidationAtom,
+  fileSystemInvalidationAtom,
+  inventoryInvalidationAtom,
+  saveFileInvalidationAtom,
+} from "../recoil/atoms"
+
+export const useInvalidateFileSystem = () =>
+  useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(fileSystemInvalidationAtom, Date.now())
+      },
+    []
+  )
+
+export const useInvalidateInventory = () =>
+  useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(inventoryInvalidationAtom, Date.now())
+      },
+    []
+  )
+
+export const useInvalidateConfig = () =>
+  useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(configInvalidationAtom, Date.now())
+      },
+    []
+  )
+
+export const useInvalidateSaveFiles = () =>
+  useRecoilCallback(
+    ({ set }) =>
+      () => {
+        set(saveFileInvalidationAtom, Date.now())
+      },
+    []
+  )

--- a/src/hooks/useInstallRequiredFiles.ts
+++ b/src/hooks/useInstallRequiredFiles.ts
@@ -1,14 +1,14 @@
 import { invoke } from "@tauri-apps/api"
 import { listen } from "@tauri-apps/api/event"
 import { useCallback, useEffect, useState } from "react"
-import { useRecoilValue, useSetRecoilState } from "recoil"
-import { fileSystemInvalidationAtom } from "../recoil/atoms"
+import { useRecoilValue } from "recoil"
 import { PocketSyncConfigSelector } from "../recoil/selectors"
 import { RequiredFileInfo } from "../types"
+import { useInvalidateFileSystem } from "./invalidation"
 
 export const useInstallRequiredFiles = (closeModal: () => void) => {
   const { archive_url } = useRecoilValue(PocketSyncConfigSelector)
-  const invalidateFS = useSetRecoilState(fileSystemInvalidationAtom)
+  const invalidateFS = useInvalidateFileSystem()
 
   const [progress, setProgress] = useState<{
     value: number
@@ -21,7 +21,7 @@ export const useInstallRequiredFiles = (closeModal: () => void) => {
       ({ payload }) => {
         setProgress(payload)
         if (payload.max === payload.value) {
-          invalidateFS(Date.now())
+          invalidateFS()
           closeModal()
         }
       }

--- a/src/recoil/saveStates/selectors.ts
+++ b/src/recoil/saveStates/selectors.ts
@@ -1,0 +1,25 @@
+import { selector, selectorFamily } from "recoil"
+import {
+  invokeReadBinaryFile,
+  invokeWalkDirListFiles,
+} from "../../utils/invokes"
+import { fileSystemInvalidationAtom } from "../atoms"
+
+export const AllSaveStatesSelector = selector<string[]>({
+  key: "AllSaveStatesSelector",
+  get: async ({ get }) => {
+    get(fileSystemInvalidationAtom)
+    const saves = await invokeWalkDirListFiles("Memories/Save States", [".sta"])
+    return saves.map((f) => f.replace(/^\//g, ""))
+  },
+})
+
+export const SaveStateBinarySelectorFamily = selectorFamily<Uint8Array, string>(
+  {
+    key: "SaveStateBinarySelectorFamily",
+    get: (path) => async () => {
+      const file = await invokeReadBinaryFile(`Memories/Save States/${path}`)
+      return file
+    },
+  }
+)

--- a/src/recoil/saveStates/selectors.ts
+++ b/src/recoil/saveStates/selectors.ts
@@ -1,4 +1,6 @@
 import { selector, selectorFamily } from "recoil"
+import { decodeThumbnail } from "../../utils/decodeSaveStateThumbnail"
+import { getBinaryMetadata } from "../../utils/getBinaryMetadata"
 import {
   invokeReadBinaryFile,
   invokeWalkDirListFiles,
@@ -23,3 +25,28 @@ export const SaveStateBinarySelectorFamily = selectorFamily<Uint8Array, string>(
     },
   }
 )
+
+export const SaveStateImageSelectorFamily = selectorFamily<string, string>({
+  key: "SaveStateImageSelectorFamily",
+  get:
+    (path) =>
+    async ({ get }) => {
+      const binary = get(SaveStateBinarySelectorFamily(path))
+      const imageSrc = decodeThumbnail(binary)
+      return imageSrc
+    },
+})
+
+export const SaveStateMetadataSelectorFamily = selectorFamily<
+  { author: string; core: string; game: string; platform: string },
+  string
+>({
+  key: "SaveStateMetadataSelectorFamily",
+  get:
+    (path) =>
+    async ({ get }) => {
+      const binary = get(SaveStateBinarySelectorFamily(path))
+      const metadata = getBinaryMetadata(binary)
+      return metadata
+    },
+})

--- a/src/recoil/screenshots/selectors.ts
+++ b/src/recoil/screenshots/selectors.ts
@@ -6,6 +6,7 @@ import {
   invokeReadBinaryFile,
   invokeReadTextFile,
 } from "../../utils/invokes"
+import { getBinaryMetadata } from "../../utils/getBinaryMetadata"
 
 export const VideoJSONSelectorFamily = selectorFamily<VideoJSON, string>({
   key: "VideoJSONSelectorFamily",
@@ -41,37 +42,13 @@ export const SingleScreenshotSelectorFamily = selectorFamily<
       )
       const buf = new Uint8Array(data)
       const file = new File([buf], fileName, { type: "image/png" })
-      const metadataBuffer = buf.slice(buf.length - 528)
-
-      let utf8decoder = new TextDecoder()
-      // The unpacking here might not be right if there's unused ranges
-
-      let authorName = utf8decoder
-        .decode(metadataBuffer.slice(0, 16 * 2))
-        .replaceAll("\u0000", "")
-
-      let coreName = utf8decoder
-        .decode(metadataBuffer.slice(16 * 2, 16 * 4))
-        .trim()
-        .replaceAll("\u0000", "")
-
-      let gameName = utf8decoder
-        .decode(metadataBuffer.slice(16 * 6, 16 * 20))
-        .trim()
-        .replaceAll("\u0000", "")
-
-      let platformName = utf8decoder
-        .decode(metadataBuffer.slice(metadataBuffer.length - 16 * 10))
-        .replaceAll("\u0000", "")
+      const metadata = getBinaryMetadata(buf, true)
 
       return {
-        file_name: fileName,
         file,
-        game: gameName,
-        platform: platformName,
+        file_name: fileName,
         timestamp: new Date(file.lastModified),
-        author: authorName,
-        core: coreName,
+        ...metadata,
       }
     },
 })

--- a/src/utils/decodeSaveStateThumbnail.ts
+++ b/src/utils/decodeSaveStateThumbnail.ts
@@ -1,0 +1,21 @@
+export const decodeThumbnail = (file: Uint8Array) => {
+  const imagePayloadSlice = file.slice(file.byteLength - 52756)
+  const canvas = document.createElement("canvas")
+  canvas.width = 122
+  canvas.height = 145
+  const context = canvas.getContext("2d") as CanvasRenderingContext2D
+  const imageDataSwap = context.getImageData(0, 0, 1, 1)
+  imageDataSwap.data[3] = 255
+  let dataIndex = 0
+  for (let x = 0; x < canvas.width - 1; x++) {
+    for (let y = 0; y < canvas.height; y++) {
+      const indexOffset = y % 4
+      imageDataSwap.data[2] = imagePayloadSlice[indexOffset + dataIndex++]
+      imageDataSwap.data[1] = imagePayloadSlice[indexOffset + dataIndex++]
+      imageDataSwap.data[0] = imagePayloadSlice[indexOffset + dataIndex++]
+      context.putImageData(imageDataSwap, canvas.width - x, y)
+    }
+    dataIndex++
+  }
+  return canvas.toDataURL()
+}

--- a/src/utils/getBinaryMetadata.ts
+++ b/src/utils/getBinaryMetadata.ts
@@ -1,0 +1,33 @@
+export const getBinaryMetadata = (buf: Uint8Array, atEnd?: true) => {
+  const metadataBuffer = atEnd
+    ? buf.slice(buf.length - 528)
+    : buf.slice(68, 424)
+
+  let utf8decoder = new TextDecoder()
+  // The unpacking here might not be right if there's unused ranges
+
+  let author = utf8decoder
+    .decode(metadataBuffer.slice(0, 16 * 2))
+    .replaceAll("\u0000", "")
+
+  let core = utf8decoder
+    .decode(metadataBuffer.slice(16 * 2, 16 * 4))
+    .trim()
+    .replaceAll("\u0000", "")
+
+  let game = utf8decoder
+    .decode(metadataBuffer.slice(16 * 6, 16 * 20))
+    .trim()
+    .replaceAll("\u0000", "")
+
+  let platform = utf8decoder
+    .decode(metadataBuffer.slice(metadataBuffer.length - 16 * 10))
+    .replaceAll("\u0000", "")
+
+  return {
+    author,
+    core,
+    game,
+    platform,
+  }
+}

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -79,3 +79,7 @@ export const invokeRestoreZip = async (zipPath: string, filePath: string) => {
 export const invokeCreateFolderIfMissing = async (path: string) => {
   return invoke<boolean>("create_folder_if_missing", { path })
 }
+
+export const invokeDeleteFiles = async (paths: string[]) => {
+  return invoke<boolean>("delete_files", { paths })
+}

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -13,10 +13,12 @@ export const invokeReadTextFile = async (path: string) =>
     path,
   })
 
-export const invokeReadBinaryFile = async (path: string) =>
-  invoke<Uint8Array>("read_binary_file", {
+export const invokeReadBinaryFile = async (path: string) => {
+  const file = await invoke<number[]>("read_binary_file", {
     path,
   })
+  return new Uint8Array(file)
+}
 
 export const invokeWalkDirListFiles = async (
   path: string,


### PR DESCRIPTION
<img width="1280" alt="Screenshot 2022-11-29 at 23 54 26" src="https://user-images.githubusercontent.com/2095051/204675547-09c2ef80-3884-4312-bb35-4914ad698232.png">

 - Only supports the save states created on v1.1 beta 6 + (the Pocket still shows the older save states too)
 - Also tidies the file system invalidation atom, will do the rest in a bit