### PR TITLE
Adds UI for removing dot files etc, misc UI things, uses real version number

### DIFF
--- a/.github/workflows/discord_announce.yml
+++ b/.github/workflows/discord_announce.yml
@@ -1,0 +1,30 @@
+name: Discord Announce
+on:
+  workflow_run:
+    workflows: [Release]
+    types:
+      - completed
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v3
+
+      - name: "Discord Notification"
+        run: |
+          curl \
+          -H "Content-Type: application/json" \
+          -d '{
+              "username": "monkeymad2",
+              "content": "New Pocket Sync release!",
+              "embeds": [{
+                  "color": 5804112,
+                  "fields": [
+                      { "name": "Link", "value": "[Click Me](https://github.com/neil-morrison44/pocket-sync/releases/latest", "inline": true }
+                  ]
+              }]
+              }' \
+          ${{ secrets.FPGAMING_DISCORD_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,4 @@
+name: Release
 on:
   workflow_dispatch:
   release:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/clean_fs.rs
+++ b/src-tauri/src/clean_fs.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+use std::{error, fs};
+use walkdir::WalkDir;
+
+pub fn find_dotfiles(root: &PathBuf) -> Result<Vec<String>, Box<dyn error::Error>> {
+    let walker = WalkDir::new(&root).into_iter();
+    let dotfiles: Vec<String> = walker
+        .into_iter()
+        .filter_map(|x| x.ok())
+        .filter(|e| e.path().is_file())
+        .filter(|e| {
+            let file_name = e.path().file_name().and_then(|f| f.to_str()).unwrap();
+
+            file_name.starts_with("._") || file_name == ".DS_Store"
+        })
+        .map(|e| String::from(e.path().to_str().unwrap()))
+        .collect();
+
+    Ok(dotfiles)
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.3.0"
+    "version": "1.4.0"
   },
   "tauri": {
     "allowlist": {
@@ -55,10 +55,10 @@
     "windows": [
       {
         "fullscreen": false,
-        "height": 600,
+        "height": 680,
         "resizable": true,
         "title": "Pocket Sync",
-        "width": 800
+        "width": 880
       }
     ]
   }

--- a/src/components/controls/index.css
+++ b/src/components/controls/index.css
@@ -15,6 +15,7 @@
   justify-content: center;
   padding: 10px 20px;
   accent-color: white;
+  text-align: center;
 
   &:hover {
     background-color: var(--hover-colour);

--- a/src/components/cores/version/index.tsx
+++ b/src/components/cores/version/index.tsx
@@ -21,14 +21,14 @@ export const Version = ({ coreName }: VersionProps) => {
 
     if (!inventoryCore?.release) return null
 
-    const { tag_name } = inventoryCore.release
+    const { version } = inventoryCore.release
     const metadataVersion = coreInfo.core.metadata.version
 
-    if (tag_name !== metadataVersion) {
-      if (tag_name.includes(metadataVersion)) {
+    if (version !== metadataVersion) {
+      if (version.includes(metadataVersion)) {
         return null
       }
-      return inventoryCore.release.tag_name
+      return inventoryCore.release.version
     }
 
     return null

--- a/src/components/games/cleanFiles/index.css
+++ b/src/components/games/cleanFiles/index.css
@@ -1,0 +1,22 @@
+.clean-files {
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.clean-files__list {
+  border-radius: 5px;
+  padding: 20px;
+  background-color: var(--info-colour);
+  flex-grow: 1;
+  overflow: auto;
+}
+
+.clean-files_button-loader {
+  height: 30px;
+  background-color: transparent;
+
+  &::before {
+    width: 40px;
+  }
+}

--- a/src/components/games/cleanFiles/index.tsx
+++ b/src/components/games/cleanFiles/index.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useRecoilValue } from "recoil"
+import { useInvalidateFileSystem } from "../../../hooks/invalidation"
+import { pocketPathAtom } from "../../../recoil/atoms"
+import { CleanableFilesSelectorFamily } from "../../../recoil/selectors"
+import {
+  invokeDeleteFiles,
+  invokeFindCleanableFiles,
+} from "../../../utils/invokes"
+import { Loader } from "../../loader"
+import { Modal } from "../../modal"
+
+import "./index.css"
+
+type CleanFilesModalProp = {
+  onClose: () => void
+  path?: string
+}
+
+export const CleanFilesModal = ({
+  onClose,
+  path = "Assets",
+}: CleanFilesModalProp) => {
+  const cleanableFiles = useRecoilValue(CleanableFilesSelectorFamily(path))
+  const [deleteInprogress, setDeleteInProgress] = useState(false)
+  const invalidateFileSystem = useInvalidateFileSystem()
+  const pocketPath = useRecoilValue(pocketPathAtom) as string
+
+  const files = useMemo(() => {
+    return cleanableFiles.map((f) => f.replace(`${pocketPath}/`, ""))
+  }, [cleanableFiles])
+
+  const deleteFiles = useCallback(async () => {
+    setDeleteInProgress(true)
+    await invokeDeleteFiles(files)
+    invalidateFileSystem()
+    setDeleteInProgress(false)
+  }, [files])
+
+  return (
+    <Modal className="clean-files">
+      <h2>Clean Files</h2>
+      <div>{`${files.length} cleanable file found`}</div>
+
+      <div className="clean-files__list">
+        {files.map((f) => (
+          <div key={f}>{f}</div>
+        ))}
+      </div>
+
+      {deleteInprogress && (
+        <button>
+          <Loader className="clean-files_button-loader" />
+        </button>
+      )}
+      {!deleteInprogress && (
+        <>
+          <button onClick={deleteFiles}>Delete Files</button>
+          <button onClick={onClose}>Close</button>
+        </>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/games/index.tsx
+++ b/src/components/games/index.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo, useState } from "react"
+import { Suspense, useCallback, useMemo, useState } from "react"
 import { useRecoilCallback, useRecoilValue } from "recoil"
 import { useCategoryLookup } from "../../hooks/useCategoryLookup"
 import { useSaveScroll } from "../../hooks/useSaveScroll"
@@ -12,12 +12,16 @@ import { Controls } from "../controls"
 import { Grid } from "../grid"
 import { Loader } from "../loader"
 import { SearchContextProvider } from "../search/context"
+import { CleanFilesModal } from "./cleanFiles"
 import { CoreFolderItem } from "./item"
 
 export const Games = () => {
   const coresList = useRecoilValue(coresListSelector)
   const [searchQuery, setSearchQuery] = useState<string>("")
   const [filterCategory, setFilterCategory] = useState<string>("All")
+
+  const [cleanFilesOpen, setCleanFilesOpen] = useState(false)
+
   const lookupCategory = useCategoryLookup()
 
   const refresh = useRecoilCallback(({ set }) => () => {
@@ -48,6 +52,10 @@ export const Games = () => {
 
   return (
     <div>
+      {cleanFilesOpen && (
+        <CleanFilesModal onClose={() => setCleanFilesOpen(false)} />
+      )}
+
       <Controls
         controls={[
           {
@@ -55,6 +63,11 @@ export const Games = () => {
             text: "Search",
             value: searchQuery,
             onChange: (v) => setSearchQuery(v),
+          },
+          {
+            type: "button",
+            text: "Clean Files",
+            onClick: () => setCleanFilesOpen(true),
           },
           {
             type: "button",

--- a/src/components/platforms/index.css
+++ b/src/components/platforms/index.css
@@ -1,5 +1,3 @@
-
-
 .platforms__editable {
   display: flex;
   align-items: center;
@@ -10,30 +8,30 @@
   & input {
     font-size: 1.5rem;
     flex-grow: 1;
-    width:1px;
+    width: 1px;
   }
 }
 
-.platforms__editable--pre-edit{
+.platforms__editable--pre-edit {
   background-color: transparent;
 
-  &:hover{
-    & .platforms__edit-button{
+  &:hover {
+    & .platforms__edit-button {
       opacity: 1;
     }
   }
 }
 
-.platforms__edit-button{
+.platforms__edit-button {
   opacity: 0;
   cursor: pointer;
 
-  &:hover{
+  &:hover {
     text-decoration: underline;
   }
 }
 
-.platform__image-editable{
+.platform__image-editable {
   position: relative;
   cursor: pointer;
 
@@ -42,7 +40,7 @@
   }
 }
 
-.platform__image-edit{
+.platform__image-edit {
   opacity: 0;
   position: absolute;
   bottom: 10px;
@@ -50,4 +48,5 @@
   background-color: var(--info-colour);
   font-size: 2rem;
   padding: 10px;
+  pointer-events: none;
 }

--- a/src/components/platforms/info/imageEditor/index.css
+++ b/src/components/platforms/info/imageEditor/index.css
@@ -1,30 +1,30 @@
-.image-editor{
+.image-editor {
   display: grid;
   grid-template-areas: "p c" "a c" "b b";
-
   grid-template-columns: min-content 1fr;
   grid-template-rows: min-content 1fr min-content;
 }
 
-.image-editor__close-button{
+.image-editor__close-button {
   cursor: pointer;
-  &:hover{
+
+  &:hover {
     font-weight: bold;
   }
 }
 
-.image-editor__preview-canvas{
+.image-editor__preview-canvas {
   grid-area: p;
   flex-grow: 0;
   flex-basis: 0;
   align-self: center;
 }
 
-.image-editor__range{
-  width: 80px;
+.image-editor__range {
+  width: clamp(80px, 10vw, 200px);
 }
 
-.image-editor__stamps-etc{
+.image-editor__stamps-etc {
   grid-area: c;
   overflow: hidden;
   display: flex;
@@ -33,7 +33,7 @@
   justify-content: space-between;
 }
 
-.image-editor__stamps{
+.image-editor__stamps {
   gap: 10px;
   align-self: flex-start;
   align-self: stretch;
@@ -42,7 +42,7 @@
   flex-direction: column;
 }
 
-.image-editor__stamp{
+.image-editor__stamp {
   display: flex;
   align-items: center;
   justify-content: space-evenly;
@@ -57,12 +57,12 @@
   border: 1px solid transparent;
 }
 
-.image-editor__stamp--selected{
+.image-editor__stamp--selected {
   background-color: var(--light-colour);
   border: 1px solid #396cd8;
 }
 
-.image-editor__stamp-image{
+.image-editor__stamp-image {
   width: 25px;
   flex-shrink: 1;
   max-width: 100px;
@@ -70,7 +70,7 @@
   flex-grow: 1;
 }
 
-.image-editor__stamp-controls{
+.image-editor__stamp-controls {
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -79,8 +79,16 @@
   flex-shrink: 1;
   flex-grow: 0;
 
-  &:empty{
+  &:empty {
     display: none;
+  }
+}
+
+.image-editor__stamp-control {
+  text-align: center;
+
+  &:hover {
+    text-decoration: underline;
   }
 }
 
@@ -97,12 +105,14 @@
   }
 }
 
-.image-editor__layer-move-button{
+.image-editor__layer-move-button {
   display: flex;
   align-items: center;
   justify-content: center;
-  &:after{
+
+  &::after {
     --size: 12px;
+
     content: "";
     display: block;
     width: var(--size);
@@ -116,14 +126,14 @@
   }
 }
 
-.image-editor__layer-move-button--up{
-  &:after{
+.image-editor__layer-move-button--up {
+  &::after {
     --rotate: 45deg;
   }
 }
 
-.image-editor__layer-move-button--down{
-  &:after{
+.image-editor__layer-move-button--down {
+  &::after {
     --rotate: 225deg;
   }
 }

--- a/src/components/platforms/info/imageEditor/index.tsx
+++ b/src/components/platforms/info/imageEditor/index.tsx
@@ -132,7 +132,8 @@ export const ImageEditor = ({
                 </div>
 
                 <div className="image-editor__stamp-controls">
-                  <button
+                  <div
+                    className="image-editor__stamp-control"
                     onClick={() => {
                       setImageStamps((stamps) =>
                         stamps.filter((s) => s !== stamp)
@@ -140,8 +141,9 @@ export const ImageEditor = ({
                     }}
                   >
                     {"Remove"}
-                  </button>
-                  <button
+                  </div>
+                  <div
+                    className="image-editor__stamp-control"
                     onClick={() =>
                       updateImageStampValues(stamp, {
                         y: 0,
@@ -152,20 +154,20 @@ export const ImageEditor = ({
                     }
                   >
                     {"Reset"}
-                  </button>
+                  </div>
                 </div>
                 <div className="image-editor__stamp-controls">
                   {index !== 0 && (
-                    <button
+                    <div
                       className="image-editor__layer-move-button image-editor__layer-move-button--up"
                       onClick={() => moveStamp(stamp, -1)}
-                    ></button>
+                    ></div>
                   )}
                   {index !== imageStamps.length - 1 && (
-                    <button
+                    <div
                       className="image-editor__layer-move-button image-editor__layer-move-button--down"
                       onClick={() => moveStamp(stamp, 1)}
-                    ></button>
+                    ></div>
                   )}
                 </div>
               </div>

--- a/src/components/saves/info/index.tsx
+++ b/src/components/saves/info/index.tsx
@@ -113,7 +113,7 @@ export const SaveInfo = ({
     )
 
     return {
-      gap: "10px",
+      gap: "5px",
       display: "grid",
       gridTemplateAreas: `'${timestamps.join(" ")}'`,
       gridTemplateColumns: `${timestamps.map(() => "1fr").join(" ")}`,
@@ -157,8 +157,12 @@ export const SaveInfo = ({
                 gridArea: getAreaName(zip.last_modified),
               }}
             >
-              <div>{date.toLocaleDateString()}</div>
-              <div>{date.toLocaleTimeString()}</div>
+              <div>{date.toLocaleDateString().replace(/\/\d{4}$/, "")}</div>
+              <div>
+                {date
+                  .toLocaleTimeString()
+                  .replace(/(\d{2}\:\d{2})\:\d{2}/, "$1")}
+              </div>
             </div>
           )
         })}

--- a/src/recoil/selectors.ts
+++ b/src/recoil/selectors.ts
@@ -16,6 +16,7 @@ import { getVersion } from "@tauri-apps/api/app"
 import { decodeDataParams } from "../utils/decodeDataParams"
 import {
   invokeFileExists,
+  invokeFindCleanableFiles,
   invokeListFiles,
   invokeReadBinaryFile,
   invokeReadTextFile,
@@ -261,5 +262,16 @@ export const ImageBinSrcSelectorFamily = selectorFamily<
           resolve(renderBinImage(response, width, height, true))
         }
       })
+    },
+})
+
+export const CleanableFilesSelectorFamily = selectorFamily<string[], string>({
+  key: "CleanableFilesSelectorFamily",
+  get:
+    (path) =>
+    async ({ get }) => {
+      get(fileSystemInvalidationAtom)
+      const files = await invokeFindCleanableFiles(path)
+      return files
     },
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,6 +120,7 @@ export type InventoryItem = {
 type InventoryItemRelease = {
   tag_name: Semver | string
   release_date: string
+  version: Semver | string
   platform: {
     category: string
     name: string

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -83,3 +83,7 @@ export const invokeCreateFolderIfMissing = async (path: string) => {
 export const invokeDeleteFiles = async (paths: string[]) => {
   return invoke<boolean>("delete_files", { paths })
 }
+
+export const invokeFindCleanableFiles = async (path: string) => {
+  return invoke<string[]>("find_cleanable_files", { path })
+}


### PR DESCRIPTION
- New option in `Games` to remove "cleanable" files (`._*` & `.DS_Store` for now, more later)
   
<img width="1284" alt="Screenshot 2022-12-02 at 14 59 44" src="https://user-images.githubusercontent.com/2095051/205331668-dbc438c6-f89c-4f64-b00b-1849d06144a0.png">

- Also tweaked some UI to better fit in narrow screens (removed years & seconds from the save header, narrowed down the buttons in the image editor)

- Switched to using the real `version` number now given by the inventory