### PR TITLE
Couple of minor tweaks to the save state list

### DIFF
--- a/src/components/cores/info/authorTag/index.tsx
+++ b/src/components/cores/info/authorTag/index.tsx
@@ -1,0 +1,17 @@
+import { useRecoilValue } from "recoil"
+import {
+  CoreInfoSelectorFamily,
+  CoreAuthorImageSelectorFamily,
+} from "../../../../recoil/selectors"
+
+export const AuthorTag = ({ coreName }: { coreName: string }) => {
+  const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
+  const authorImageSrc = useRecoilValue(CoreAuthorImageSelectorFamily(coreName))
+
+  return (
+    <div className="core-info__author-tag">
+      <img src={authorImageSrc} />
+      {coreInfo.core.metadata.author}
+    </div>
+  )
+}

--- a/src/components/cores/info/installed.tsx
+++ b/src/components/cores/info/installed.tsx
@@ -25,6 +25,7 @@ import { SponsorLinks } from "./sponsorLinks"
 import { RequiredFiles } from "./requiredFiles"
 import { LoadRequiredFiles } from "./loadRequiredFiles"
 import { ErrorBoundary } from "../../errorBoundary"
+import { AuthorTag } from "./authorTag"
 
 type CoreInfoProps = {
   coreName: string
@@ -33,7 +34,6 @@ type CoreInfoProps = {
 
 export const InstalledCoreInfo = ({ coreName, onBack }: CoreInfoProps) => {
   const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
-  const authorImageSrc = useRecoilValue(CoreAuthorImageSelectorFamily(coreName))
   const uninstall = useUninstallCore()
   const { installCore } = useInstallCore()
   const inventoryItem = useInventoryItem(coreName)
@@ -95,10 +95,7 @@ export const InstalledCoreInfo = ({ coreName, onBack }: CoreInfoProps) => {
 
           <div className="core-info__info-row">
             <strong>{"Author:"}</strong>
-            <div className="core-info__author-tag">
-              <img src={authorImageSrc} />
-              {coreInfo.core.metadata.author}
-            </div>
+            <AuthorTag coreName={coreName} />
           </div>
 
           {inventoryItem?.sponsor && (

--- a/src/components/saveStates/index.css
+++ b/src/components/saveStates/index.css
@@ -14,8 +14,12 @@
   flex-wrap: wrap;
 }
 
-.save-states__items:empty + .save-states__core-header {
+.save-states__items:empty {
   display: none;
+
+  & + .save-states__core-header {
+    display: none;
+  }
 }
 
 .save-states__core-header {

--- a/src/components/saveStates/index.css
+++ b/src/components/saveStates/index.css
@@ -1,28 +1,40 @@
-.save-states{
+.save-states {
   --controls-height: 55px;
 }
 
+.save-states__list {
+  display: flex;
+  flex-direction: column-reverse;
+}
 
-.save-states__items{
+.save-states__items {
   display: flex;
   gap: 8px;
   padding: 10px;
   flex-wrap: wrap;
 }
 
-.save-states__core-header{
-  background-color: var(--hover-colour);
-  padding: 10px 20px;
-
-  position: sticky;
-  top: var(--controls-height);
-
-  display: flex;
-  justify-content: space-between;
+.save-states__items:empty + .save-states__core-header {
+  display: none;
 }
 
-.save-states__item{
+.save-states__core-header {
+  background-color: var(--hover-colour);
+  padding: 10px 20px;
+  position: sticky;
+  top: var(--controls-height);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.save-states__core-header-count {
+  margin-left: auto;
+}
+
+.save-states__item {
   --flex-size: 50%;
+
   display: flex;
   align-items: center;
   background-color: var(--info-colour);
@@ -33,7 +45,7 @@
   cursor: pointer;
   border: 2px solid transparent;
 
-  &:hover{
+  &:hover {
     transform: scale(1.05);
   }
 
@@ -54,17 +66,17 @@
   border-color: #396cd8;
 }
 
-.save-states__item-info{
+.save-states__item-info {
   display: flex;
   flex-direction: column;
   gap: 10px;
 }
 
-.save-states__item-name{
+.save-states__item-name {
   font-weight: bold;
 }
 
-.save-states__item-image{
+.save-states__item-image {
   flex-shrink: 0;
   width: 123px;
   height: auto;

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -11,6 +11,7 @@ import { SearchContextProvider } from "../search/context"
 import { confirm } from "@tauri-apps/api/dialog"
 import { invokeDeleteFiles } from "../../utils/invokes"
 import { useInvalidateFileSystem } from "../../hooks/invalidation"
+import { AuthorTag } from "../cores/info/authorTag"
 
 export const SaveStates = () => {
   const invalidateFS = useInvalidateFileSystem()
@@ -77,11 +78,10 @@ export const SaveStates = () => {
               },
         ]}
       />
-      <div>
+      <div className="save-states__list">
         <SearchContextProvider query={searchQuery}>
-          {Object.entries(groupByCore).map(([coreName, saveStates]) => (
+          {Object.entries(groupByCore).map(([coreName, saveStates], index) => (
             <Fragment key={coreName}>
-              <CoreNameHeader coreName={coreName} count={saveStates.length} />
               <div className="save-states__items">
                 {saveStates.map((p) => (
                   <Suspense fallback={<Loader />} key={p}>
@@ -98,6 +98,11 @@ export const SaveStates = () => {
                   </Suspense>
                 ))}
               </div>
+              <CoreNameHeader
+                coreName={coreName}
+                count={saveStates.length}
+                zIndex={Object.values(groupByCore).length - index}
+              />
             </Fragment>
           ))}
         </SearchContextProvider>
@@ -109,16 +114,18 @@ export const SaveStates = () => {
 const CoreNameHeader = ({
   coreName,
   count,
+  zIndex,
 }: {
   coreName: string
   count: number
+  zIndex: number
 }) => {
   const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
 
   return (
-    <div className="save-states__core-header">
-      {`${coreInfo.core.metadata.shortname}`}
-
+    <div className="save-states__core-header" style={{ zIndex }}>
+      <AuthorTag coreName={coreName} />
+      <b>{`${coreInfo.core.metadata.shortname}`}</b>
       <div className="save-states__core-header-count">{`( ${count} / 128 )`}</div>
     </div>
   )


### PR DESCRIPTION
<img width="868" alt="Screenshot 2022-12-05 at 22 48 15" src="https://user-images.githubusercontent.com/2095051/205759624-d83cabd6-3df0-4fb9-a699-44e9abd1346d.png">

- Now includes the author name in the title since (in theory) multiple core implementations can have separate save states
- Also now hides the titles of empty groups, since before if you did a search you'd need to scroll through all the empty sections to find it
- Also now sorts the cores by most recent, but that was accidental