### PR TITLE
Fixes cartridge game save states & screenshots, also windows save backups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/saves_zip.rs
+++ b/src-tauri/src/saves_zip.rs
@@ -176,14 +176,19 @@ pub fn build_save_zip(
     Ok(())
 }
 
-fn remove_leading_slash(value: &str) -> &str {
-    if !value.starts_with("/") {
-        return value;
+fn remove_leading_slash(value: &str) -> String {
+    let mut result = String::new();
+    let mut chars = value.chars();
+
+    while let Some(c) = chars.next() {
+        if !(c == '/' || c == '\\') {
+            result.push(c);
+            break;
+        }
     }
 
-    let mut chars = value.chars();
-    chars.next();
-    chars.as_str()
+    result.push_str(chars.as_str());
+    result
 }
 
 fn sha256_digest<R: Read>(mut reader: R) -> Result<Digest, Box<dyn error::Error>> {

--- a/src-tauri/src/saves_zip.rs
+++ b/src-tauri/src/saves_zip.rs
@@ -138,7 +138,8 @@ pub fn build_save_zip(
 
     let mut buffer = Vec::new();
     for name in save_paths {
-        let path = saves_path.join(name);
+        let safe_name = remove_leading_slash(name);
+        let path = saves_path.join(&safe_name);
         let metadata = path.metadata().unwrap();
         let last_modified = time::OffsetDateTime::from(metadata.modified().unwrap());
 
@@ -155,13 +156,13 @@ pub fn build_save_zip(
         );
 
         if path.is_file() {
-            zip.start_file(name, file_options).unwrap();
+            zip.start_file(&safe_name, file_options).unwrap();
             let mut f = File::open(path).unwrap();
             f.read_to_end(&mut buffer).unwrap();
             zip.write_all(&*buffer).unwrap();
             buffer.clear();
         } else {
-            zip.add_directory(name, options).unwrap();
+            zip.add_directory(&safe_name, options).unwrap();
         }
     }
     zip.finish().unwrap();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.4.1"
+    "version": "1.4.2"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/saveStates/index.css
+++ b/src/components/saveStates/index.css
@@ -78,6 +78,7 @@
 
 .save-states__item-name {
   font-weight: bold;
+  overflow-wrap: break-word;
 }
 
 .save-states__item-image {

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -22,7 +22,7 @@ export const SaveStates = () => {
   const groupByCore = useMemo(
     () =>
       allSaveStates.reduce((g, p) => {
-        const coreName = p.substring(0, p.indexOf("/"))
+        const coreName = p.substring(0, p.indexOf("/")) || "Native"
 
         const existing = g[coreName]
         if (existing) {
@@ -84,7 +84,10 @@ export const SaveStates = () => {
             <Fragment key={coreName}>
               <div className="save-states__items">
                 {saveStates.map((p) => (
-                  <Suspense fallback={<Loader />} key={p}>
+                  <Suspense
+                    fallback={<Loader className="save-states__item" />}
+                    key={p}
+                  >
                     <SaveStateItem
                       path={p}
                       selected={selectedStates.includes(p)}
@@ -98,11 +101,21 @@ export const SaveStates = () => {
                   </Suspense>
                 ))}
               </div>
-              <CoreNameHeader
-                coreName={coreName}
-                count={saveStates.length}
-                zIndex={Object.values(groupByCore).length - index}
-              />
+              {coreName === "Native" && (
+                <CartridgeHeader
+                  count={saveStates.length}
+                  zIndex={Object.values(groupByCore).length - index}
+                />
+              )}
+              {coreName !== "Native" && (
+                <Suspense fallback={<Loader />}>
+                  <CoreNameHeader
+                    coreName={coreName}
+                    count={saveStates.length}
+                    zIndex={Object.values(groupByCore).length - index}
+                  />
+                </Suspense>
+              )}
             </Fragment>
           ))}
         </SearchContextProvider>
@@ -110,6 +123,19 @@ export const SaveStates = () => {
     </div>
   )
 }
+
+const CartridgeHeader = ({
+  count,
+  zIndex,
+}: {
+  count: number
+  zIndex: number
+}) => (
+  <div className="save-states__core-header" style={{ zIndex }}>
+    <b>{"Cartridge"}</b>
+    <div className="save-states__core-header-count">{`( ${count} / 128 )`}</div>
+  </div>
+)
 
 const CoreNameHeader = ({
   coreName,

--- a/src/components/saveStates/item.tsx
+++ b/src/components/saveStates/item.tsx
@@ -26,6 +26,7 @@ export const SaveStateItem = ({
 
   const gameName = useMemo(() => {
     const { game } = metadata
+    if (!game.includes(".")) return game
     const filetypeIndex = game.lastIndexOf(".")
     return game.substring(0, filetypeIndex)
   }, [metadata.game])
@@ -58,7 +59,7 @@ export const SaveStateItem = ({
 
 const useSaveStateDate = (path: string) => {
   return useMemo(() => {
-    const dateRegex = /\/(?<year>\d{8})_(?<time>\d{6})_/g
+    const dateRegex = /\/?(?<year>\d{8})_(?<time>\d{6})_/g
     const match = dateRegex.exec(path)
     if (!match?.groups) return null
 

--- a/src/recoil/saveStates/selectors.ts
+++ b/src/recoil/saveStates/selectors.ts
@@ -1,6 +1,9 @@
 import { selector, selectorFamily } from "recoil"
 import { decodeThumbnail } from "../../utils/decodeSaveStateThumbnail"
-import { getBinaryMetadata } from "../../utils/getBinaryMetadata"
+import {
+  getBinaryMetadata,
+  getCartridgeBinaryMetadata,
+} from "../../utils/getBinaryMetadata"
 import {
   invokeReadBinaryFile,
   invokeWalkDirListFiles,
@@ -46,7 +49,9 @@ export const SaveStateMetadataSelectorFamily = selectorFamily<
     (path) =>
     async ({ get }) => {
       const binary = get(SaveStateBinarySelectorFamily(path))
-      const metadata = getBinaryMetadata(binary)
+      const metadata = !path.includes("/")
+        ? getCartridgeBinaryMetadata(binary, false)
+        : getBinaryMetadata(binary)
       return metadata
     },
 })

--- a/src/recoil/screenshots/selectors.ts
+++ b/src/recoil/screenshots/selectors.ts
@@ -2,6 +2,7 @@ import { selector, selectorFamily } from "recoil"
 import { Screenshot, VideoJSON } from "../../types"
 import { fileSystemInvalidationAtom } from "../atoms"
 import {
+  invokeFileExists,
   invokeListFiles,
   invokeReadBinaryFile,
   invokeReadTextFile,
@@ -14,6 +15,14 @@ export const VideoJSONSelectorFamily = selectorFamily<VideoJSON, string>({
     (coreName) =>
     async ({ get }) => {
       get(fileSystemInvalidationAtom)
+      const exists = await invokeFileExists(`Cores/${coreName}/video.json`)
+      if (!exists)
+        return {
+          video: {
+            scaler_modes: [],
+            magic: "APF_VER_1",
+          },
+        }
       const jsonText = await invokeReadTextFile(`Cores/${coreName}/video.json`)
       return JSON.parse(jsonText) as VideoJSON
     },

--- a/src/utils/getBinaryMetadata.ts
+++ b/src/utils/getBinaryMetadata.ts
@@ -1,4 +1,34 @@
-export const getBinaryMetadata = (buf: Uint8Array, atEnd?: true) => {
+type Metadata = {
+  author: string
+  core: string
+  game: string
+  platform: string
+}
+
+export const getCartridgeBinaryMetadata = (
+  buf: Uint8Array,
+  atEnd?: boolean
+): Metadata => {
+  const metadataBuffer = atEnd
+    ? buf.slice(buf.length - 528)
+    : buf.slice(0x01c, 424)
+
+  let utf8decoder = new TextDecoder()
+
+  let game = utf8decoder
+    .decode(metadataBuffer.slice(0, 16 * 20))
+    .trim()
+    .replaceAll("\u0000", "")
+
+  return {
+    author: "Native",
+    core: "Native",
+    game,
+    platform: "Native",
+  }
+}
+
+export const getBinaryMetadata = (buf: Uint8Array, atEnd?: boolean) => {
   const metadataBuffer = atEnd
     ? buf.slice(buf.length - 528)
     : buf.slice(68, 424)


### PR DESCRIPTION
Fixes #24 & Fixes #23 

- Cartridge based save states & screenshots are now output, unfortunately they contain a lot less metadata than the OpenFPGA core ones so screenshots don't know the name of the game & all cartridge save states get lumped together
- Windows save backup zips are being built now at least, also fixes 1 UI thing I noticed being off in windows (but there's others still...)