### PR TITLE
Fixes some longstanding windows issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pocket-sync",
-  "version": "1.2.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pocket-sync",
-      "version": "1.2.1",
+      "version": "1.4.2",
       "dependencies": {
         "@react-three/drei": "^9.40.0",
         "@react-three/fiber": "^8.9.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -67,9 +67,9 @@ async fn read_text_file(
 ) -> Result<String, ()> {
     let pocket_path = state.0.read().await;
     let path = pocket_path.join(path);
-    // println!("reading text file: {:?}", &path);
-    let video_json = fs::read_to_string(path).unwrap();
-    Ok(video_json)
+    //println!("reading text file: {:?}", &path);
+    let file_contents = fs::read_to_string(path).unwrap();
+    Ok(file_contents)
 }
 
 #[tauri::command(async)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.4.2"
+    "version": "1.4.3"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/about/index.css
+++ b/src/components/about/index.css
@@ -5,6 +5,9 @@
   justify-content: space-between;
   height: 100vh;
   text-align: center;
+  overflow: hidden;
+  width: calc(100vw - var(--sidebar-width));
+  flex-shrink: 1;
 }
 
 .about__update-link {
@@ -20,19 +23,14 @@
   display: flex;
   flex-direction: column;
   justify-content: space-around;
-
-  /* width: 100%; */
-  width: max-content;
-  text-align: center;
-  align-items: center;
   gap: 10px;
+  width: 100%;
 }
 
 .about__info {
   background-color: var(--info-colour);
   width: 100%;
   max-height: fit-content;
-  flex-grow: 1;
   justify-self: flex-end;
   text-align: left;
   padding: 0 20px;

--- a/src/components/controls/index.css
+++ b/src/components/controls/index.css
@@ -50,6 +50,7 @@
   font-family: inherit;
   width: 200px;
   transition: border-color 0.25s;
+  min-height: 35px;
 }
 
 .controls__item--select {

--- a/src/components/layout/index.css
+++ b/src/components/layout/index.css
@@ -1,6 +1,9 @@
 .layout {
   display: flex;
   align-items: flex-start;
+  width: 100vw;
+  max-width: 100vw;
+  position: relative;
 }
 
 .layout__sidebar-menu {

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useState } from "react"
+import React, { Suspense, useEffect, useRef, useState } from "react"
 import { About } from "../about"
 import { AutoRefresh } from "../autoRefresh"
 import { Cores } from "../cores"
@@ -27,12 +27,30 @@ export const Layout = () => {
   ] as const
   const [viewName, setViewName] = useState<typeof views[number]>("Pocket Sync")
 
+  const sidebarRef = useRef<HTMLDivElement>(null)
+  const layoutRef = useRef<HTMLDivElement>(null)
+
+
+  useEffect(() => {
+    const sidebar = sidebarRef.current
+    if (!sidebar) return
+
+    const {width} = sidebar.getBoundingClientRect()
+
+    const layout = layoutRef.current
+    if (!layout) return
+
+    layout.style.setProperty("--sidebar-width", `${width}px`)
+
+  }, [])
+
+
   return (
-    <div className="layout">
+    <div className="layout" ref={layoutRef}>
       <Disconnections />
       <ZipInstall />
       <AutoRefresh />
-      <div className="layout__sidebar-menu">
+      <div className="layout__sidebar-menu" ref={sidebarRef}>
         {views.map((v) => (
           <div
             className={`layout__sidebar-menu-item ${

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -12,6 +12,7 @@ import { confirm } from "@tauri-apps/api/dialog"
 import { invokeDeleteFiles } from "../../utils/invokes"
 import { useInvalidateFileSystem } from "../../hooks/invalidation"
 import { AuthorTag } from "../cores/info/authorTag"
+import { splitAsPath } from "../../utils/splitAsPath"
 
 export const SaveStates = () => {
   const invalidateFS = useInvalidateFileSystem()
@@ -22,7 +23,10 @@ export const SaveStates = () => {
   const groupByCore = useMemo(
     () =>
       allSaveStates.reduce((g, p) => {
-        const coreName = p.substring(0, p.indexOf("/")) || "Native"
+        const pathSplit = splitAsPath(p)
+        const coreName = pathSplit.length > 1 ? pathSplit[0] : "Native"
+
+        console.log({coreName, pathSplit})
 
         const existing = g[coreName]
         if (existing) {

--- a/src/components/saves/info/index.tsx
+++ b/src/components/saves/info/index.tsx
@@ -19,6 +19,7 @@ import { ask } from "@tauri-apps/api/dialog"
 import { saveFileInvalidationAtom } from "../../../recoil/atoms"
 import { useSaveScroll } from "../../../hooks/useSaveScroll"
 import { useInvalidateSaveFiles } from "../../../hooks/invalidation"
+import { splitAsPath } from "../../../utils/splitAsPath"
 
 export const SaveInfo = ({
   backupPath,
@@ -82,7 +83,8 @@ export const SaveInfo = ({
     const groups: { platform: PlatformId; saves: typeof filteredSaves }[] = []
 
     Object.entries(filteredSaves).forEach(([key, value]) => {
-      const [_, platformId] = key.split("/")
+      console.log({key, value})
+      const [platformId] = splitAsPath(key)
       const existing = groups.find(({ platform }) => platformId === platform)
 
       if (existing) {

--- a/src/utils/splitAsPath.ts
+++ b/src/utils/splitAsPath.ts
@@ -1,0 +1,12 @@
+import {platform, Platform} from "@tauri-apps/api/os"
+
+let PLATFORM: null | Platform  = null
+platform().then((p) => PLATFORM = p)
+
+export const splitAsPath = (filePath: string): string[] => {
+    if (PLATFORM === "win32"){
+        return filePath.split("\\").filter(Boolean)
+    } else {
+        return filePath.split("/").filter(Boolean)
+    }
+}


### PR DESCRIPTION
- Save States should now have the platform information shown in the header
- The spinning Pocket shouldn't get its edges clipped anymore & the thanks section just takes up the space it needs
- Viewing save backups should work

(90% of the windows issues is just due to it needing `\\` instead of `/`)