### PR TITLE
Speeds up showing grid items by only loading on screen ones

### DIFF
--- a/src/components/cores/index.tsx
+++ b/src/components/cores/index.tsx
@@ -104,7 +104,10 @@ export const Cores = () => {
       <SearchContextProvider query={searchQuery}>
         <Grid>
           {sortedList.map((core) => (
-            <Suspense fallback={<Loader title={core} />} key={core}>
+            <Suspense
+              fallback={<Loader title={core} height={160} />}
+              key={core}
+            >
               <CoreItem
                 coreName={core}
                 onClick={() => {

--- a/src/components/games/index.tsx
+++ b/src/components/games/index.tsx
@@ -86,7 +86,7 @@ export const Games = () => {
       <SearchContextProvider query={searchQuery}>
         <Grid>
           {sortedList.map((core) => (
-            <Suspense fallback={<Loader />} key={core}>
+            <Suspense fallback={<Loader height={130} />} key={core}>
               <CoreFolderItem coreName={core} />
             </Suspense>
           ))}

--- a/src/components/grid/index.tsx
+++ b/src/components/grid/index.tsx
@@ -1,11 +1,66 @@
-import { ReactNode } from "react"
+import {
+  Children,
+  MutableRefObject,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import "./index.css"
 
 type GridProps = {
   children: ReactNode
   className?: string
+  placeholderItemHeight?: number
 }
 
-export const Grid = ({ children, className }: GridProps) => {
-  return <div className={`grid ${className ?? ""}`}>{children}</div>
+export const Grid = ({
+  children,
+  className,
+  placeholderItemHeight = 200,
+}: GridProps) => {
+  const items = Children.toArray(children)
+
+  return (
+    <div className={`grid ${className ?? ""}`}>
+      {Children.toArray(
+        items.map((i) => (
+          <OnlyLoadsWhenShown height={placeholderItemHeight}>
+            {i}
+          </OnlyLoadsWhenShown>
+        ))
+      )}
+    </div>
+  )
+}
+
+const OnlyLoadsWhenShown = ({
+  height,
+  children,
+}: {
+  height: number
+  children: ReactNode
+}) => {
+  const placeHolderDivRef = useRef<HTMLDivElement>(null)
+  const hasBeenShown = useHasBeenShown(placeHolderDivRef)
+  if (!hasBeenShown)
+    return <div ref={placeHolderDivRef} style={{ height: `${height}px` }}></div>
+  return <>{children}</>
+}
+
+const useHasBeenShown = (element: MutableRefObject<HTMLElement | null>) => {
+  const [hasBeenShown, setState] = useState(false)
+  useEffect(() => {
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting && element.current) {
+        setState(true)
+        observer.unobserve(element.current)
+      }
+    })
+    element.current && observer.observe(element.current)
+    return () => {
+      element.current && observer.unobserve(element.current)
+    }
+  }, [])
+  return hasBeenShown
 }

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -1,4 +1,10 @@
-import React, { Suspense, useEffect, useRef, useState } from "react"
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { About } from "../about"
 import { AutoRefresh } from "../autoRefresh"
 import { Cores } from "../cores"
@@ -27,23 +33,28 @@ export const Layout = () => {
   ] as const
   const [viewName, setViewName] = useState<typeof views[number]>("Pocket Sync")
 
+  const changeView = useCallback(
+    (viewName: typeof views[number]) => {
+      setViewName(viewName)
+      window.scrollTo({ top: 0 })
+    },
+    [setViewName]
+  )
+
   const sidebarRef = useRef<HTMLDivElement>(null)
   const layoutRef = useRef<HTMLDivElement>(null)
-
 
   useEffect(() => {
     const sidebar = sidebarRef.current
     if (!sidebar) return
 
-    const {width} = sidebar.getBoundingClientRect()
+    const { width } = sidebar.getBoundingClientRect()
 
     const layout = layoutRef.current
     if (!layout) return
 
     layout.style.setProperty("--sidebar-width", `${width}px`)
-
   }, [])
-
 
   return (
     <div className="layout" ref={layoutRef}>
@@ -57,7 +68,7 @@ export const Layout = () => {
               viewName === v ? "layout__sidebar-menu-item--active" : ""
             }`}
             key={v}
-            onClick={() => setViewName(v)}
+            onClick={() => changeView(v)}
           >
             {v}
           </div>

--- a/src/components/loader/index.tsx
+++ b/src/components/loader/index.tsx
@@ -5,11 +5,18 @@ type LoaderProps = {
   className?: string
   fullHeight?: boolean
   title?: string
+  height?: number
 }
 
-export const Loader = ({ className, fullHeight, title = "" }: LoaderProps) => (
+export const Loader = ({
+  className,
+  fullHeight,
+  height,
+  title = "",
+}: LoaderProps) => (
   <div
     className={`loader ${className || ""} ${fullHeight ? "loader--full" : ""}`}
     title={title}
+    style={{ height: height ? `${height}px` : undefined }}
   ></div>
 )

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -26,8 +26,6 @@ export const SaveStates = () => {
         const pathSplit = splitAsPath(p)
         const coreName = pathSplit.length > 1 ? pathSplit[0] : "Native"
 
-        console.log({coreName, pathSplit})
-
         const existing = g[coreName]
         if (existing) {
           existing.push(p)

--- a/src/components/saves/info/index.tsx
+++ b/src/components/saves/info/index.tsx
@@ -83,7 +83,6 @@ export const SaveInfo = ({
     const groups: { platform: PlatformId; saves: typeof filteredSaves }[] = []
 
     Object.entries(filteredSaves).forEach(([key, value]) => {
-      console.log({key, value})
       const [platformId] = splitAsPath(key)
       const existing = groups.find(({ platform }) => platformId === platform)
 

--- a/src/recoil/saves/selectors.ts
+++ b/src/recoil/saves/selectors.ts
@@ -60,7 +60,6 @@ export const AllBackupZipsFilesSelectorFamily = selectorFamily<
     (backupPath) =>
     async ({ get }) => {
       const { files } = get(BackupZipsSelectorFamily(backupPath))
-      console.log({ files })
       return files.map((zip) => ({
         zip,
         files: get(


### PR DESCRIPTION
- Now there's loads of cores there can be a big wait for them to load, this should decrease that by only loading the ones that are on screen
- Also applies to screenshots & Games & Platforms (but not save states since those aren't the same grid thing)