### PR TITLE
Adds deep links throughout the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.6.0"
+    "version": "1.6.1"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/controls/index.css
+++ b/src/components/controls/index.css
@@ -58,6 +58,7 @@
   gap: 5px;
   align-items: center;
   font-size: 1.125rem;
+  flex-wrap: wrap;
 
   & > select {
     font-size: 1.125rem;

--- a/src/components/cores/index.tsx
+++ b/src/components/cores/index.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo, useState } from "react"
-import { useRecoilCallback, useRecoilValue } from "recoil"
+import { useRecoilCallback, useRecoilState, useRecoilValue } from "recoil"
 import { useSaveScroll } from "../../hooks/useSaveScroll"
 import {
   fileSystemInvalidationAtom,
@@ -8,6 +8,7 @@ import {
 import { cateogryListselector } from "../../recoil/inventory/selectors"
 import { CoreInventorySelector } from "../../recoil/inventory/selectors"
 import { coresListSelector } from "../../recoil/selectors"
+import { selectedSubviewSelector } from "../../recoil/view/selectors"
 import { Controls } from "../controls"
 import { Grid } from "../grid"
 import { Loader } from "../loader"
@@ -17,7 +18,9 @@ import { CoreInfo } from "./info"
 import { CoreItem, NotInstalledCoreItem } from "./item"
 
 export const Cores = () => {
-  const [selectedCore, setSelectedCore] = useState<string | null>(null)
+  const [selectedCore, setSelectedCore] = useRecoilState(
+    selectedSubviewSelector
+  )
   const coresList = useRecoilValue(coresListSelector)
   const coreInventory = useRecoilValue(CoreInventorySelector)
   const { pushScroll, popScroll } = useSaveScroll()

--- a/src/components/cores/info/installed.tsx
+++ b/src/components/cores/info/installed.tsx
@@ -26,7 +26,7 @@ import { SponsorLinks } from "./sponsorLinks"
 import { RequiredFiles } from "./requiredFiles"
 import { LoadRequiredFiles } from "./loadRequiredFiles"
 import { ErrorBoundary } from "../../errorBoundary"
-import { AuthorTag } from "./authorTag"
+import { AuthorTag } from "../../shared/authorTag"
 
 type CoreInfoProps = {
   coreName: string

--- a/src/components/cores/info/platform/index.css
+++ b/src/components/cores/info/platform/index.css
@@ -23,6 +23,14 @@
   font-size: 1.25rem;
 }
 
+.cores__platform-info-edit {
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+
 .cores__platform-info-cateogry {
   border-right: 1px solid white;
   padding-right: 15px;

--- a/src/components/cores/info/platform/index.tsx
+++ b/src/components/cores/info/platform/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react"
-import { useRecoilValue } from "recoil"
+import { useRecoilValue, useSetRecoilState } from "recoil"
 import { PlatformInfoSelectorFamily } from "../../../../recoil/platforms/selectors"
+import { currentViewAtom } from "../../../../recoil/view/atoms"
 import { PlatformId } from "../../../../types"
 import { Link } from "../../../link"
 
@@ -15,6 +16,8 @@ type CorePlatformInfoProps = {
 export const CorePlatformInfo = ({ platformId }: CorePlatformInfoProps) => {
   const { platform } = useRecoilValue(PlatformInfoSelectorFamily(platformId))
 
+  const setViewAndSubview = useSetRecoilState(currentViewAtom)
+
   const wikiLink = useMemo(() => {
     const searchTerm = HARD_TO_FIND_THINGS.includes(platform.name)
       ? `${platform.manufacturer} ${platform.name}`
@@ -28,12 +31,27 @@ export const CorePlatformInfo = ({ platformId }: CorePlatformInfoProps) => {
   return (
     <div className="cores__platform-info">
       <div className="cores__platform-info-cateogry">{platform.category}</div>
-      <strong className="cores__platform-info-name">{platform.name}</strong>
+      <strong
+        className="cores__platform-info-name"
+        title="View / Edit platform info"
+      >
+        {platform.name}
+      </strong>
 
       <div>{`${platform.manufacturer}, ${platform.year}`}</div>
       <Link className="cores__platform-info-wiki" href={wikiLink}>
         {"Wikipedia"}
       </Link>
+
+      <div
+        className="cores__platform-info-edit"
+        onClick={() =>
+          setViewAndSubview({ view: "Platforms", selected: platformId })
+        }
+        title="View / Edit platform info"
+      >
+        {"Edit"}
+      </div>
     </div>
   )
 }

--- a/src/components/games/item.tsx
+++ b/src/components/games/item.tsx
@@ -20,9 +20,9 @@ export const CoreFolderItem = ({ coreName }: { coreName: string }) => {
 
   const romsSlot = useMemo(
     () =>
-      data.data.data_slots
-        .filter(({ required, extensions }) => required && extensions)
-        .at(0),
+      data.data.data_slots.filter(
+        ({ required, extensions }) => required && extensions
+      )[0],
     [data]
   )
 

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -5,6 +5,8 @@ import React, {
   useRef,
   useState,
 } from "react"
+import { useRecoilState } from "recoil"
+import { currentViewAtom, VIEWS_LIST } from "../../recoil/view/atoms"
 import { About } from "../about"
 import { AutoRefresh } from "../autoRefresh"
 import { Cores } from "../cores"
@@ -21,24 +23,14 @@ import { ZipInstall } from "../zipInstall"
 import "./index.css"
 
 export const Layout = () => {
-  const views = [
-    "Pocket Sync",
-    "Games",
-    "Cores",
-    "Screenshots",
-    "Saves",
-    "Save States",
-    "Platforms",
-    "Settings",
-  ] as const
-  const [viewName, setViewName] = useState<typeof views[number]>("Pocket Sync")
+  const [viewAndSubview, setViewAndSubview] = useRecoilState(currentViewAtom)
 
   const changeView = useCallback(
-    (viewName: typeof views[number]) => {
-      setViewName(viewName)
+    (viewName: typeof VIEWS_LIST[number]) => {
+      setViewAndSubview({ view: viewName, selected: null })
       window.scrollTo({ top: 0 })
     },
-    [setViewName]
+    [setViewAndSubview]
   )
 
   const sidebarRef = useRef<HTMLDivElement>(null)
@@ -56,16 +48,18 @@ export const Layout = () => {
     layout.style.setProperty("--sidebar-width", `${width}px`)
   }, [])
 
+  const { view } = viewAndSubview
+
   return (
     <div className="layout" ref={layoutRef}>
       <Disconnections />
       <ZipInstall />
       <AutoRefresh />
       <div className="layout__sidebar-menu" ref={sidebarRef}>
-        {views.map((v) => (
+        {VIEWS_LIST.map((v) => (
           <div
             className={`layout__sidebar-menu-item ${
-              viewName === v ? "layout__sidebar-menu-item--active" : ""
+              view === v ? "layout__sidebar-menu-item--active" : ""
             }`}
             key={v}
             onClick={() => changeView(v)}
@@ -77,14 +71,14 @@ export const Layout = () => {
       <div className="layout__content">
         <ErrorBoundary>
           <Suspense fallback={<Loader fullHeight />}>
-            {viewName === "Screenshots" && <Screenshots />}
-            {viewName === "Cores" && <Cores />}
-            {viewName === "Pocket Sync" && <About />}
-            {viewName === "Settings" && <Settings />}
-            {viewName === "Games" && <Games />}
-            {viewName === "Saves" && <Saves />}
-            {viewName === "Save States" && <SaveStates />}
-            {viewName === "Platforms" && <Platforms />}
+            {view === "Screenshots" && <Screenshots />}
+            {view === "Cores" && <Cores />}
+            {view === "Pocket Sync" && <About />}
+            {view === "Settings" && <Settings />}
+            {view === "Games" && <Games />}
+            {view === "Saves" && <Saves />}
+            {view === "Save States" && <SaveStates />}
+            {view === "Platforms" && <Platforms />}
           </Suspense>
         </ErrorBoundary>
       </div>

--- a/src/components/platforms/index.css
+++ b/src/components/platforms/index.css
@@ -50,3 +50,14 @@
   padding: 10px;
   pointer-events: none;
 }
+
+.platform-info__cores-title {
+  padding: 0 10px;
+}
+
+.platform-info__cores-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 20px;
+}

--- a/src/components/platforms/index.tsx
+++ b/src/components/platforms/index.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useMemo, useState } from "react"
-import { useRecoilValue } from "recoil"
+import { useRecoilState, useRecoilValue } from "recoil"
 import { useSaveScroll } from "../../hooks/useSaveScroll"
 import { platformsListSelector } from "../../recoil/platforms/selectors"
 import { PlatformId } from "../../types"
@@ -11,14 +11,15 @@ import { PlatformInfo } from "./info"
 import { PlatformItem } from "./item"
 
 import "./index.css"
+import { selectedSubviewSelector } from "../../recoil/view/selectors"
 
 export const Platforms = () => {
   const [searchQuery, setSearchQuery] = useState("")
   const platformIds = useRecoilValue(platformsListSelector)
   const { pushScroll, popScroll } = useSaveScroll()
 
-  const [selectedPlatform, setSelectedPlatform] = useState<PlatformId | null>(
-    null
+  const [selectedPlatform, setSelectedPlatform] = useRecoilState(
+    selectedSubviewSelector
   )
 
   const sortedPlatformIds = useMemo(

--- a/src/components/platforms/info/coresForPlatform/index.tsx
+++ b/src/components/platforms/info/coresForPlatform/index.tsx
@@ -1,0 +1,19 @@
+import { useRecoilValue } from "recoil"
+import { CoresForPlatformSelectorFamily } from "../../../../recoil/platforms/selectors"
+import { PlatformId } from "../../../../types"
+import { CoreTag } from "../../../shared/coreTag"
+
+export const CoresForPlatform = ({
+  platformId,
+}: {
+  platformId: PlatformId
+}) => {
+  const cores = useRecoilValue(CoresForPlatformSelectorFamily(platformId))
+  return (
+    <div className="platform-info__cores-list">
+      {cores.map((coreName) => (
+        <CoreTag coreName={coreName} key={coreName} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/platforms/info/index.tsx
+++ b/src/components/platforms/info/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { Suspense, useMemo, useState } from "react"
 import { useRecoilValue } from "recoil"
 import {
   PlatformInfoSelectorFamily,
@@ -8,7 +8,9 @@ import {
 import { PlatformId } from "../../../types"
 import { PLATFORM_IMAGE } from "../../../values"
 import { Controls } from "../../controls"
+import { Loader } from "../../loader"
 import { useUpdatePlatformValue } from "../hooks/useUpdatePlatform"
+import { CoresForPlatform } from "./coresForPlatform"
 import { Editable } from "./editable"
 import { ImageEditor } from "./imageEditor"
 
@@ -85,6 +87,13 @@ export const PlatformInfo = ({ id, onBack }: PlatformInfoProps) => {
             type="number"
             onSave={(v) => updateValue("year", v)}
           />
+        </div>
+
+        <div>
+          <h3 className="platform-info__cores-title">Cores: </h3>
+          <Suspense fallback={<Loader />}>
+            <CoresForPlatform platformId={id} />
+          </Suspense>
         </div>
       </div>
     </div>

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -11,8 +11,9 @@ import { SearchContextProvider } from "../search/context"
 import { confirm } from "@tauri-apps/api/dialog"
 import { invokeDeleteFiles } from "../../utils/invokes"
 import { useInvalidateFileSystem } from "../../hooks/invalidation"
-import { AuthorTag } from "../cores/info/authorTag"
+import { AuthorTag } from "../shared/authorTag"
 import { splitAsPath } from "../../utils/splitAsPath"
+import { CoreTag } from "../shared/coreTag"
 
 export const SaveStates = () => {
   const invalidateFS = useInvalidateFileSystem()
@@ -148,12 +149,9 @@ const CoreNameHeader = ({
   count: number
   zIndex: number
 }) => {
-  const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
-
   return (
     <div className="save-states__core-header" style={{ zIndex }}>
-      <AuthorTag coreName={coreName} />
-      <b>{`${coreInfo.core.metadata.shortname}`}</b>
+      <CoreTag coreName={coreName} />
       <div className="save-states__core-header-count">{`( ${count} / 128 )`}</div>
     </div>
   )

--- a/src/components/saves/item.tsx
+++ b/src/components/saves/item.tsx
@@ -44,10 +44,10 @@ export const SavesItem = ({ config, onClickRestore }: SavesItemProps) => {
         {files.length > 0 && (
           <>
             <div>{`Last Backup: ${new Date(
-              (files.at(-1)?.last_modified || 0) * 1000
+              (files[files.length - 1]?.last_modified || 0) * 1000
             ).toLocaleString()}`}</div>
             <div>{`Oldest Backup: ${new Date(
-              (files.at(0)?.last_modified || 0) * 1000
+              (files[0]?.last_modified || 0) * 1000
             ).toLocaleString()}`}</div>
           </>
         )}

--- a/src/components/screenshots/index.tsx
+++ b/src/components/screenshots/index.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, useMemo, useState } from "react"
-import { useRecoilValue } from "recoil"
+import { useRecoilState, useRecoilValue } from "recoil"
 import { screenshotsListSelector } from "../../recoil/screenshots/selectors"
 import { Screenshot } from "./item"
 
@@ -10,9 +10,10 @@ import { Grid } from "../grid"
 import { useSaveScroll } from "../../hooks/useSaveScroll"
 import { Controls } from "../controls"
 import { SearchContextProvider } from "../search/context"
+import { selectedSubviewSelector } from "../../recoil/view/selectors"
 
 export const Screenshots = () => {
-  const [selected, setSelected] = useState<string | null>(null)
+  const [selected, setSelected] = useRecoilState(selectedSubviewSelector)
   const [searchQuery, setSearchQuery] = useState("")
   const screenshots = useRecoilValue(screenshotsListSelector)
 

--- a/src/components/screenshots/info.tsx
+++ b/src/components/screenshots/info.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React, { Suspense, useCallback, useMemo, useState } from "react"
 import { useRecoilValue } from "recoil"
 import { SingleScreenshotSelectorFamily } from "../../recoil/screenshots/selectors"
 import { VideoJSONSelectorFamily } from "../../recoil/screenshots/selectors"
@@ -6,6 +6,8 @@ import "./info.css"
 
 import { useSaveFile } from "../../hooks/saveFile"
 import { Controls } from "../controls"
+import { CoreTag } from "../shared/coreTag"
+import { Loader } from "../loader"
 
 type ScreenshotInfo = {
   fileName: string
@@ -110,7 +112,12 @@ export const ScreenshotInfo = ({ fileName, onBack }: ScreenshotInfo) => {
 
       <div className="screenshot-info__info">
         <div>{screenshot.game}</div>
-        <div>{screenshot.platform}</div>
+        {screenshot.platform && <div>{`Platform: ${screenshot.platform}`}</div>}
+        {screenshot.core && screenshot.author && (
+          <Suspense fallback={<Loader />}>
+            <CoreTag coreName={`${screenshot.author}.${screenshot.core}`} />
+          </Suspense>
+        )}
         <div>{screenshot.file_name}</div>
       </div>
     </div>

--- a/src/components/shared/authorTag/index.tsx
+++ b/src/components/shared/authorTag/index.tsx
@@ -2,7 +2,7 @@ import { useRecoilValue } from "recoil"
 import {
   CoreInfoSelectorFamily,
   CoreAuthorImageSelectorFamily,
-} from "../../../../recoil/selectors"
+} from "../../../recoil/selectors"
 
 export const AuthorTag = ({ coreName }: { coreName: string }) => {
   const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))

--- a/src/components/shared/coreTag/index.css
+++ b/src/components/shared/coreTag/index.css
@@ -1,0 +1,10 @@
+.core-tag {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--hover-colour);
+  }
+}

--- a/src/components/shared/coreTag/index.tsx
+++ b/src/components/shared/coreTag/index.tsx
@@ -1,0 +1,21 @@
+import { useRecoilValue, useSetRecoilState } from "recoil"
+import { CoreInfoSelectorFamily } from "../../../recoil/selectors"
+import { currentViewAtom } from "../../../recoil/view/atoms"
+import { AuthorTag } from "../authorTag"
+
+import "./index.css"
+
+export const CoreTag = ({ coreName }: { coreName: string }) => {
+  const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
+  const viewCore = useSetRecoilState(currentViewAtom)
+
+  return (
+    <div
+      className="core-tag"
+      onClick={() => viewCore({ view: "Cores", selected: coreName })}
+    >
+      <AuthorTag coreName={coreName} />
+      <b>{`${coreInfo.core.metadata.shortname}`}</b>
+    </div>
+  )
+}

--- a/src/recoil/platforms/selectors.ts
+++ b/src/recoil/platforms/selectors.ts
@@ -1,14 +1,13 @@
 import { selector, selectorFamily } from "recoil"
 import { PlatformId, PlatformInfoJSON } from "../../types"
-import {
-  invokeListFiles,
-  invokeReadBinaryFile,
-  invokeReadTextFile,
-} from "../../utils/invokes"
-import { renderBinImage } from "../../utils/renderBinImage"
+import { invokeListFiles, invokeReadTextFile } from "../../utils/invokes"
 import { PLATFORM_IMAGE } from "../../values"
 import { fileSystemInvalidationAtom } from "../atoms"
-import { ImageBinSrcSelectorFamily } from "../selectors"
+import {
+  CoreInfoSelectorFamily,
+  coresListSelector,
+  ImageBinSrcSelectorFamily,
+} from "../selectors"
 
 export const platformsListSelector = selector<PlatformId[]>({
   key: "platformsListSelector",
@@ -19,6 +18,28 @@ export const platformsListSelector = selector<PlatformId[]>({
       .filter((s) => s.endsWith(".json"))
       .map((s) => s.replace(".json", ""))
   },
+})
+
+export const CoresForPlatformSelectorFamily = selectorFamily<
+  string[],
+  PlatformId
+>({
+  key: "CoresForPlatformSelectorFamily",
+  get:
+    (platformId: PlatformId) =>
+    ({ get }) => {
+      const coresList = get(coresListSelector)
+      const results = []
+      for (const coreId of coresList) {
+        const coreData = get(CoreInfoSelectorFamily(coreId))
+
+        if (coreData.core.metadata.platform_ids.includes(platformId)) {
+          results.push(coreId)
+        }
+      }
+
+      return results
+    },
 })
 
 export const PlatformInfoSelectorFamily = selectorFamily<

--- a/src/recoil/view/atoms.ts
+++ b/src/recoil/view/atoms.ts
@@ -1,0 +1,36 @@
+import { atom } from "recoil"
+
+export const VIEWS_LIST = [
+  "Pocket Sync",
+  "Games",
+  "Cores",
+  "Screenshots",
+  "Saves",
+  "Save States",
+  "Platforms",
+  "Settings",
+] as const
+
+export type ViewAndSubview =
+  | {
+      view:
+        | "Pocket Sync"
+        | "Games"
+        | "Saves"
+        | "Save States"
+        | "Platforms"
+        | "Settings"
+      selected: null
+    }
+  | {
+      view: "Cores" | "Screenshots" | "Platforms"
+      selected: string | null
+    }
+
+export const currentViewAtom = atom<ViewAndSubview>({
+  key: "currentViewAtom",
+  default: {
+    view: "Pocket Sync",
+    selected: null,
+  },
+})

--- a/src/recoil/view/selectors.ts
+++ b/src/recoil/view/selectors.ts
@@ -1,0 +1,24 @@
+import { DefaultValue, selector } from "recoil"
+import { currentViewAtom } from "./atoms"
+
+export const selectedSubviewSelector = selector<string | null>({
+  key: "selectedSubviewSelector",
+  get: ({ get }) => {
+    const currentView = get(currentViewAtom)
+    return currentView.selected
+  },
+  set: ({ set, get }, newValue) => {
+    const currentView = get(currentViewAtom)
+
+    if (newValue instanceof DefaultValue) {
+      set(currentViewAtom, { ...currentView, selected: null })
+    } else if (
+      currentView.view === "Platforms" ||
+      currentView.view === "Screenshots" ||
+      currentView.view === "Cores"
+    ) {
+      // @ts-ignore
+      set(currentViewAtom, { ...currentView, selected: newValue })
+    }
+  },
+})


### PR DESCRIPTION
- Adds "deep" links throughout the app, so now you can go straight from a Core's info page to the platform page then back to the specific core, or from a screenshot to the core that took the screenshot etc

<img width="1045" alt="Screenshot 2022-12-12 at 00 28 54" src="https://user-images.githubusercontent.com/2095051/206938802-f2413caa-acd7-4bee-81bf-be0b2cf87017.png">

- Also fixes https://github.com/neil-morrison44/pocket-sync/issues/32 (though there might be other new JS / CSS things I've used which also aren't compatible)