### PR TITLE
Better error for rate limiting & window remembers position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "1.7.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -93,6 +93,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2067,6 +2076,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-window-state",
  "tempdir",
  "time",
  "tokio",
@@ -2994,6 +3004,18 @@ dependencies = [
  "syn",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f15dab0be2ce3ce8a57d0d2de17d201d0c2f3230d68981ff3f0942684de03eb"
+dependencies = [
+ "bincode",
+ "serde",
+ "tauri",
+ "thiserror",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ time = "0.3.17"
 ring = "0.16.20"
 data-encoding = "2.3.2"
 faccess = "0.2.4"
+tauri-plugin-window-state = "0.1.0"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -362,6 +362,7 @@ async fn settings_folder_readonly(
 
 fn main() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .manage(PocketSyncState(Default::default()))
         .invoke_handler(tauri::generate_handler![
             open_pocket,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "1.7.0"
+    "version": "2.0.0"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/errorBoundary/index.css
+++ b/src/components/errorBoundary/index.css
@@ -1,5 +1,9 @@
 .error-boundary {
   padding: 20px;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  box-sizing: border-box;
 }
 
 .error-boundary__message {
@@ -9,4 +13,6 @@
 
 .error-boundary__stack {
   white-space: pre-wrap;
+  flex-grow: 1;
+  overflow: auto;
 }

--- a/src/components/errorBoundary/index.tsx
+++ b/src/components/errorBoundary/index.tsx
@@ -31,6 +31,11 @@ export class ErrorBoundary extends Component<
     console.error("Uncaught error:", error, errorInfo)
   }
 
+  clearError() {
+    console.log("clear error?")
+    this.setState({ hasError: false, error: null })
+  }
+
   public render() {
     if (this.state.hasError) {
       return (
@@ -49,6 +54,10 @@ export class ErrorBoundary extends Component<
             {this.state.error?.message}
           </div>
           <div className="error-boundary__stack">{this.state.error?.stack}</div>
+
+          <button style={{ width: "100%" }} onClick={() => this.clearError()}>
+            Retry
+          </button>
         </div>
       )
     }

--- a/src/recoil/github/selectors.ts
+++ b/src/recoil/github/selectors.ts
@@ -15,6 +15,20 @@ export const GithubReleasesSelectorFamily = selectorFamily<
         `https://api.github.com/repos/${owner}/${repo}/releases`
       )
 
+      const remainingRateLimit = parseInt(
+        response.headers.get("x-ratelimit-remaining") || "60"
+      )
+
+      if (remainingRateLimit < 1) {
+        const timeTillReset = parseInt(
+          response.headers.get("x-ratelimit-reset") || "0"
+        )
+        const resetDate = new Date(timeTillReset * 1000)
+        throw new Error(
+          `GitHub rate limit reached, retry after ${resetDate.toLocaleString()}`
+        )
+      }
+
       return (await response.json()) as GithubRelease[]
     },
 })


### PR DESCRIPTION
- Improves the error encountered by https://github.com/neil-morrison44/pocket-sync/issues/39 & https://github.com/neil-morrison44/pocket-sync/issues/40 , doesn't (yet) use the `.token`, will do that if there's people running into the rate limiting in everyday usage & I'll add info on how to set it up to the new error message
- the error page now has a "retry" button which'll clear the error state & (hopefully) allow whatever caused it to retry (works well if you move away from the tab that errored)
<img width="1127" alt="Screenshot 2022-12-24 at 03 23 52" src="https://user-images.githubusercontent.com/2095051/209419503-3806d0ee-e4cb-4e02-9e98-7e9b1051638b.png">
- Also now remembers where / what size the window was set to
- Also version bumps to v2.0.0 so hopefully more people move on to the next version with the updated inventory API url
