### PR TITLE
Adds multi-screenshot export & delete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "pocket-sync",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pocket-sync",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
-        "@react-three/drei": "^9.46.4",
-        "@react-three/fiber": "^8.9.1",
+        "@react-three/drei": "^9.51.15",
+        "@react-three/fiber": "^8.10.0",
         "@tauri-apps/api": "^1.2.0",
-        "@types/three": "^0.146.0",
+        "@types/three": "^0.148.0",
         "date-fns": "^2.29.3",
         "fast-fuzzy": "^1.12.0",
         "react": "^18.2.0",
@@ -19,19 +19,19 @@
         "react-markdown": "^8.0.4",
         "recoil": "^0.7.6",
         "remark-gfm": "^3.0.1",
-        "three": "^0.146.0"
+        "three": "^0.148.0"
       },
       "devDependencies": {
         "@tauri-apps/cli": "^1.2.2",
-        "@types/node": "^18.11.9",
-        "@types/react": "^18.0.25",
-        "@types/react-dom": "^18.0.9",
-        "@vitejs/plugin-react": "^3.0.0",
+        "@types/node": "^18.11.18",
+        "@types/react": "^18.0.26",
+        "@types/react-dom": "^18.0.10",
+        "@vitejs/plugin-react": "^3.0.1",
         "postcss-nesting": "^10.2.0",
-        "stylelint": "^14.16.0",
+        "stylelint": "^14.16.1",
         "stylelint-config-standard": "^29.0.0",
         "typescript": "^4.9.4",
-        "vite": "^4.0.0"
+        "vite": "^4.0.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -60,34 +60,34 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz",
-      "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==",
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
-      "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.0",
-        "@babel/helper-module-transforms": "^7.20.2",
-        "@babel/helpers": "^7.20.5",
-        "@babel/parser": "^7.20.5",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.12",
+        "@babel/types": "^7.20.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -99,12 +99,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
-      "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.20.5",
+        "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -127,14 +127,15 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-      "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.20.0",
+        "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -143,6 +144,21 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.18.9",
@@ -191,9 +207,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -201,9 +217,9 @@
         "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.2"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -270,14 +286,14 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
-      "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -298,9 +314,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -351,33 +367,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
-      "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
+      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.5",
+        "@babel/generator": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.5",
-        "@babel/types": "^7.20.5",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -386,9 +402,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
-      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -932,26 +948,26 @@
       "integrity": "sha512-7I/qY8H7Enwasxr4jU6WmtNK+RZ4Z/XvSlDvjXFVe7ii1x0MoSlkw6pD7xuac8qrHQRm9BTcbZNyeeKApYsvCg=="
     },
     "node_modules/@react-three/drei": {
-      "version": "9.46.4",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.46.4.tgz",
-      "integrity": "sha512-jrX+gMHlLLcjOy4VvjGEJz6EauzKUXscLi2hmLUhTZ2PI4SwcaZJNKf4KP639XqA4CL1fpIkA/GTmBwVKTUn8A==",
+      "version": "9.51.15",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.51.15.tgz",
+      "integrity": "sha512-PGeJudHY2P9FFsqzhbILXntWo6OmMi9r/+A4AfguYnekWZndqjyWROyurUdXKB95CYPg6R4i8y13osVbRnII9Q==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@react-spring/three": "^9.3.1",
         "@use-gesture/react": "^10.2.0",
-        "detect-gpu": "^5.0.1",
+        "detect-gpu": "^5.0.5",
         "glsl-noise": "^0.0.0",
         "lodash.clamp": "^4.0.3",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
-        "meshline": "^3.0.4",
+        "meshline": "^3.1.6",
         "react-composer": "^5.0.3",
         "react-merge-refs": "^1.1.0",
         "stats.js": "^0.17.0",
         "suspend-react": "^0.0.8",
-        "three-mesh-bvh": "^0.5.19",
+        "three-mesh-bvh": "^0.5.21",
         "three-stdlib": "^2.20.4",
-        "troika-three-text": "^0.46.4",
+        "troika-three-text": "^0.47.1",
         "utility-types": "^3.10.0",
         "zustand": "^3.5.13"
       },
@@ -983,22 +999,6 @@
         "three": ">=0.126"
       }
     },
-    "node_modules/@react-three/drei/node_modules/meshline": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.0.4.tgz",
-      "integrity": "sha512-o4kwwnhgYLyNwcB6i+qHejuN9l129p7mdF0vsqzWEAHGw5SBwD9q0ut+tX3G3om8PUW7GOQQa5V4t3I7wMN41Q==",
-      "peerDependencies": {
-        "three": ">=0.137"
-      }
-    },
-    "node_modules/@react-three/drei/node_modules/three-mesh-bvh": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.19.tgz",
-      "integrity": "sha512-Q8huT0NautyR4afW0oMlOz8a4qm3b1jQ1ccMLF/TZ0rA4i58HljsnBjCLEDLQtIINZyLtZPdw60mrD81V/TZDA==",
-      "peerDependencies": {
-        "three": ">= 0.123.0"
-      }
-    },
     "node_modules/@react-three/drei/node_modules/three-stdlib": {
       "version": "2.20.4",
       "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.20.4.tgz",
@@ -1020,32 +1020,10 @@
         "three": ">=0.122.0"
       }
     },
-    "node_modules/@react-three/drei/node_modules/troika-three-text": {
-      "version": "0.46.4",
-      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.46.4.tgz",
-      "integrity": "sha512-Qsv0HhUKTZgSmAJs5wvO7YlBoJSP9TGPLmrg+K9pbQq4lseQdcevbno/WI38bwJBZ/qS56hvfqEzY0zUEFzDIw==",
-      "dependencies": {
-        "bidi-js": "^1.0.2",
-        "troika-three-utils": "^0.46.0",
-        "troika-worker-utils": "^0.46.0",
-        "webgl-sdf-generator": "1.1.1"
-      },
-      "peerDependencies": {
-        "three": ">=0.103.0"
-      }
-    },
-    "node_modules/@react-three/drei/node_modules/troika-three-text/node_modules/troika-three-utils": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.46.0.tgz",
-      "integrity": "sha512-llHyrXAcwzr0bpg80GxsIp73N7FuImm4WCrKDJkAqcAsWmE5pfP9+Qzw+oMWK1P/AdHQ79eOrOl9NjyW4aOw0w==",
-      "peerDependencies": {
-        "three": ">=0.103.0"
-      }
-    },
     "node_modules/@react-three/fiber": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.9.1.tgz",
-      "integrity": "sha512-xRMO9RGp0DkxSFu5BmmkjCxJ4r0dEpLobtxXdZwI0h2rZZaCnkPM5zThRN8xaZNbZhzRSVICeNOFaZltr9xFyQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.10.0.tgz",
+      "integrity": "sha512-veyvW9clPjS0oQ4g8e2E8yW3v8C2wcXhJp3VyTgjzhpKYAL0xq0+aiofHdpNjx/CiqlR25mYyFky6HskWP3B5w==",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -1304,9 +1282,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1342,9 +1320,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.9.tgz",
-      "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -1364,9 +1342,9 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "node_modules/@types/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.148.0.tgz",
+      "integrity": "sha512-1GiErjt1pJMadO8EhaxNrtULzdn+f3BbM3YTukiiXBVeRvvx4CXc2rpYdEuEBU/ouCX7Rc95j1HoVG9kFQXQJw==",
       "dependencies": {
         "@types/webxr": "*"
       }
@@ -1398,12 +1376,12 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.0.tgz",
-      "integrity": "sha512-1mvyPc0xYW5G8CHQvJIJXLoMjl5Ct3q2g5Y2s6Ccfgwm45y48LBvsla7az+GkkAtYikWQ4Lxqcsq5RHLcZgtNQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.1.tgz",
+      "integrity": "sha512-mx+QvYwIbbpOIJw+hypjnW1lAbKDHtWK5ibkF/V1/oMBu8HU/chb+SnqJDAsLq1+7rGqjktCEomMTM5KShzUKQ==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.20.5",
+        "@babel/core": "^7.20.7",
         "@babel/plugin-transform-react-jsx-self": "^7.18.6",
         "@babel/plugin-transform-react-jsx-source": "^7.19.6",
         "magic-string": "^0.27.0",
@@ -1600,9 +1578,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "dev": true,
       "funding": [
         {
@@ -1832,9 +1810,9 @@
       }
     },
     "node_modules/detect-gpu": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.2.tgz",
-      "integrity": "sha512-1lAXK0NWhsZYhhqwVWGQYRsTlY+9DL9cB80+4fBMo9GRLuAKCK4MzEz5Rc+F/4RDgnAFPzrsMcnmnDU007X3NQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.5.tgz",
+      "integrity": "sha512-gKBKx8mj0Fi/8DnjuzxU+aNYF1yWvPxtiOV9o72539wW0HP3ZTJVol/0FUasvdxIY1Bhi19SwIINqXGO+RB/sA==",
       "dependencies": {
         "webgl-constants": "^1.1.1"
       }
@@ -2899,6 +2877,14 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshline": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.1.6.tgz",
+      "integrity": "sha512-8JZJOdaL5oz3PI/upG8JvP/5FfzYUOhrkJ8np/WKvXzl0/PZ2V9pqTvCIjSKv+w9ccg2xb+yyBhXAwt6ier3ug==",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
     "node_modules/micromark": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
@@ -3515,9 +3501,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
     },
     "node_modules/normalize-package-data": {
@@ -4460,9 +4446,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "14.16.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.0.tgz",
-      "integrity": "sha512-X6uTi9DcxjzLV8ZUAjit1vsRtSwcls0nl07c9rqOPzvpA8IvTX/xWEkBRowS0ffevRrqkHa/ThDEu86u73FQDg==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
@@ -4625,9 +4611,17 @@
       }
     },
     "node_modules/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A=="
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.148.0.tgz",
+      "integrity": "sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw=="
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.21.tgz",
+      "integrity": "sha512-TGXPk7YwtlU5rgQJYA25OT6yAdBMeekfC4BTkGNtTWA5glb2rmEpjxvhZncRQSl73QZir2LFOQT0FjfzgG55xw==",
+      "peerDependencies": {
+        "three": ">= 0.123.0"
+      }
     },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
@@ -4673,10 +4667,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.1.tgz",
+      "integrity": "sha512-/fPRUmxCkXxyUT8k6REC/aWeFzKbNr37ivrkrplSJNb3JcBUXvVt8MT0Ac5wTUvFsYTviYWprYS4/8Laen08WA==",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.47.0",
+        "troika-worker-utils": "^0.47.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.47.0.tgz",
+      "integrity": "sha512-yoVTQxVbpQX3a55giIwqwq6hyJA6oYvq7kaNGwFTeicoWmTZCqqTbytafx1gcuL5umrtw5MYgsxYUSOha+xp5w==",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
     "node_modules/troika-worker-utils": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.46.0.tgz",
-      "integrity": "sha512-bzOx5f2ZBxkFhXtIvDJlLn2AI3bzCkGVbCndl/2dL5QZrwHEKl45OEIilCxYQQWJG1rEbOD9O80tMjoYjw19OA=="
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.47.0.tgz",
+      "integrity": "sha512-PSUc9vunDEkbE23jpgXD3PcF96jQHKjgMjS+4o5g6DEK/ZAPTnldb+FNddhppawfUcuraMFrslo0GmIC8UpEmA=="
     },
     "node_modules/trough": {
       "version": "2.1.0",
@@ -4942,13 +4958,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.0.tgz",
-      "integrity": "sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.16.3",
-        "postcss": "^8.4.19",
+        "postcss": "^8.4.20",
         "resolve": "^1.22.1",
         "rollup": "^3.7.0"
       },
@@ -5107,41 +5123,41 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.5.tgz",
-      "integrity": "sha512-KZXo2t10+/jxmkhNXc7pZTqRvSOIvVv/+lJwHS+B2rErwOyjuVRh60yVpb7liQ1U5t7lLJ1bz+t8tSypUZdm0g==",
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
-      "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.0",
-        "@babel/helper-module-transforms": "^7.20.2",
-        "@babel/helpers": "^7.20.5",
-        "@babel/parser": "^7.20.5",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.12",
+        "@babel/types": "^7.20.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.5.tgz",
-      "integrity": "sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.20.5",
+        "@babel/types": "^7.20.7",
         "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
@@ -5160,15 +5176,33 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.0.tgz",
-      "integrity": "sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.20.0",
+        "@babel/compat-data": "^7.20.5",
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -5206,9 +5240,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.2.tgz",
-      "integrity": "sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.18.9",
@@ -5216,9 +5250,9 @@
         "@babel/helper-simple-access": "^7.20.2",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "@babel/helper-validator-identifier": "^7.19.1",
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.1",
-        "@babel/types": "^7.20.2"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-plugin-utils": {
@@ -5264,14 +5298,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.6.tgz",
-      "integrity": "sha512-Pf/OjgfgFRW5bApskEz5pvidpim7tEDPlFtKcNRXWmfHGn9IEI2W2flqRQXTFb7gIPTyK++N6rVHuwKut4XK6w==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.20.5",
-        "@babel/types": "^7.20.5"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/highlight": {
@@ -5286,9 +5320,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.5.tgz",
-      "integrity": "sha512-r27t/cy/m9uKLXQNWWebeCUHgnAZq0CpG1OwKRxzJMP1vpSU4bSIK2hq+/cp0bQxetkXx38n09rNu8jVkcK/zA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "dev": true
     },
     "@babel/plugin-transform-react-jsx-self": {
@@ -5318,38 +5352,38 @@
       }
     },
     "@babel/template": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-      "integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/parser": "^7.18.10",
-        "@babel/types": "^7.18.10"
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.5.tgz",
-      "integrity": "sha512-WM5ZNN3JITQIq9tFZaw1ojLU3WgWdtkxnhM1AegMS+PvHjkM5IXjmYEGY7yukz5XS4sJyEf2VzWjI8uAavhxBQ==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
+      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
-        "@babel/generator": "^7.20.5",
+        "@babel/generator": "^7.20.7",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.20.5",
-        "@babel/types": "^7.20.5",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.5.tgz",
-      "integrity": "sha512-c9fst/h2/dcF7H+MJKZ2T0KjEQ8hY/BNnDk/H3XY8C4Aw/eWQXWn/lWntHF9ooUBnGmEvbfGrTgLWc+um0YDUg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dev": true,
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
@@ -5651,26 +5685,26 @@
       "integrity": "sha512-7I/qY8H7Enwasxr4jU6WmtNK+RZ4Z/XvSlDvjXFVe7ii1x0MoSlkw6pD7xuac8qrHQRm9BTcbZNyeeKApYsvCg=="
     },
     "@react-three/drei": {
-      "version": "9.46.4",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.46.4.tgz",
-      "integrity": "sha512-jrX+gMHlLLcjOy4VvjGEJz6EauzKUXscLi2hmLUhTZ2PI4SwcaZJNKf4KP639XqA4CL1fpIkA/GTmBwVKTUn8A==",
+      "version": "9.51.15",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-9.51.15.tgz",
+      "integrity": "sha512-PGeJudHY2P9FFsqzhbILXntWo6OmMi9r/+A4AfguYnekWZndqjyWROyurUdXKB95CYPg6R4i8y13osVbRnII9Q==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@react-spring/three": "^9.3.1",
         "@use-gesture/react": "^10.2.0",
-        "detect-gpu": "^5.0.1",
+        "detect-gpu": "^5.0.5",
         "glsl-noise": "^0.0.0",
         "lodash.clamp": "^4.0.3",
         "lodash.omit": "^4.5.0",
         "lodash.pick": "^4.4.0",
-        "meshline": "^3.0.4",
+        "meshline": "^3.1.6",
         "react-composer": "^5.0.3",
         "react-merge-refs": "^1.1.0",
         "stats.js": "^0.17.0",
         "suspend-react": "^0.0.8",
-        "three-mesh-bvh": "^0.5.19",
+        "three-mesh-bvh": "^0.5.21",
         "three-stdlib": "^2.20.4",
-        "troika-three-text": "^0.46.4",
+        "troika-three-text": "^0.47.1",
         "utility-types": "^3.10.0",
         "zustand": "^3.5.13"
       },
@@ -5685,18 +5719,6 @@
             "@react-spring/shared": "~9.5.5",
             "@react-spring/types": "~9.5.5"
           }
-        },
-        "meshline": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.0.4.tgz",
-          "integrity": "sha512-o4kwwnhgYLyNwcB6i+qHejuN9l129p7mdF0vsqzWEAHGw5SBwD9q0ut+tX3G3om8PUW7GOQQa5V4t3I7wMN41Q==",
-          "requires": {}
-        },
-        "three-mesh-bvh": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.19.tgz",
-          "integrity": "sha512-Q8huT0NautyR4afW0oMlOz8a4qm3b1jQ1ccMLF/TZ0rA4i58HljsnBjCLEDLQtIINZyLtZPdw60mrD81V/TZDA==",
-          "requires": {}
         },
         "three-stdlib": {
           "version": "2.20.4",
@@ -5715,32 +5737,13 @@
             "potpack": "^1.0.1",
             "zstddec": "^0.0.2"
           }
-        },
-        "troika-three-text": {
-          "version": "0.46.4",
-          "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.46.4.tgz",
-          "integrity": "sha512-Qsv0HhUKTZgSmAJs5wvO7YlBoJSP9TGPLmrg+K9pbQq4lseQdcevbno/WI38bwJBZ/qS56hvfqEzY0zUEFzDIw==",
-          "requires": {
-            "bidi-js": "^1.0.2",
-            "troika-three-utils": "^0.46.0",
-            "troika-worker-utils": "^0.46.0",
-            "webgl-sdf-generator": "1.1.1"
-          },
-          "dependencies": {
-            "troika-three-utils": {
-              "version": "0.46.0",
-              "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.46.0.tgz",
-              "integrity": "sha512-llHyrXAcwzr0bpg80GxsIp73N7FuImm4WCrKDJkAqcAsWmE5pfP9+Qzw+oMWK1P/AdHQ79eOrOl9NjyW4aOw0w==",
-              "requires": {}
-            }
-          }
         }
       }
     },
     "@react-three/fiber": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.9.1.tgz",
-      "integrity": "sha512-xRMO9RGp0DkxSFu5BmmkjCxJ4r0dEpLobtxXdZwI0h2rZZaCnkPM5zThRN8xaZNbZhzRSVICeNOFaZltr9xFyQ==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.10.0.tgz",
+      "integrity": "sha512-veyvW9clPjS0oQ4g8e2E8yW3v8C2wcXhJp3VyTgjzhpKYAL0xq0+aiofHdpNjx/CiqlR25mYyFky6HskWP3B5w==",
       "requires": {
         "@babel/runtime": "^7.17.8",
         "@types/react-reconciler": "^0.26.7",
@@ -5873,9 +5876,9 @@
       "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "@types/node": {
-      "version": "18.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.13.tgz",
-      "integrity": "sha512-IASpMGVcWpUsx5xBOrxMj7Bl8lqfuTY7FKAnPmu5cHkfQVWF8GulWS1jbRqA934qZL35xh5xN/+Xe/i26Bod4w==",
+      "version": "18.11.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
+      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -5911,9 +5914,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.9.tgz",
-      "integrity": "sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==",
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.10.tgz",
+      "integrity": "sha512-E42GW/JA4Qv15wQdqJq8DL4JhNpB3prJgjgapN3qJT9K2zO5IIAQh4VXvCEDupoqAwnz0cY4RlXeC/ajX5SFHg==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -5933,9 +5936,9 @@
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
     },
     "@types/three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==",
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.148.0.tgz",
+      "integrity": "sha512-1GiErjt1pJMadO8EhaxNrtULzdn+f3BbM3YTukiiXBVeRvvx4CXc2rpYdEuEBU/ouCX7Rc95j1HoVG9kFQXQJw==",
       "requires": {
         "@types/webxr": "*"
       }
@@ -5964,12 +5967,12 @@
       }
     },
     "@vitejs/plugin-react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.0.tgz",
-      "integrity": "sha512-1mvyPc0xYW5G8CHQvJIJXLoMjl5Ct3q2g5Y2s6Ccfgwm45y48LBvsla7az+GkkAtYikWQ4Lxqcsq5RHLcZgtNQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.0.1.tgz",
+      "integrity": "sha512-mx+QvYwIbbpOIJw+hypjnW1lAbKDHtWK5ibkF/V1/oMBu8HU/chb+SnqJDAsLq1+7rGqjktCEomMTM5KShzUKQ==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.20.5",
+        "@babel/core": "^7.20.7",
         "@babel/plugin-transform-react-jsx-self": "^7.18.6",
         "@babel/plugin-transform-react-jsx-source": "^7.19.6",
         "magic-string": "^0.27.0",
@@ -6108,9 +6111,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "dev": true
     },
     "ccount": {
@@ -6271,9 +6274,9 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
     },
     "detect-gpu": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.2.tgz",
-      "integrity": "sha512-1lAXK0NWhsZYhhqwVWGQYRsTlY+9DL9cB80+4fBMo9GRLuAKCK4MzEz5Rc+F/4RDgnAFPzrsMcnmnDU007X3NQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.5.tgz",
+      "integrity": "sha512-gKBKx8mj0Fi/8DnjuzxU+aNYF1yWvPxtiOV9o72539wW0HP3ZTJVol/0FUasvdxIY1Bhi19SwIINqXGO+RB/sA==",
       "requires": {
         "webgl-constants": "^1.1.1"
       }
@@ -7078,6 +7081,12 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
+    "meshline": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.1.6.tgz",
+      "integrity": "sha512-8JZJOdaL5oz3PI/upG8JvP/5FfzYUOhrkJ8np/WKvXzl0/PZ2V9pqTvCIjSKv+w9ccg2xb+yyBhXAwt6ier3ug==",
+      "requires": {}
+    },
     "micromark": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.1.0.tgz",
@@ -7435,9 +7444,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
       "dev": true
     },
     "normalize-package-data": {
@@ -8115,9 +8124,9 @@
       }
     },
     "stylelint": {
-      "version": "14.16.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.0.tgz",
-      "integrity": "sha512-X6uTi9DcxjzLV8ZUAjit1vsRtSwcls0nl07c9rqOPzvpA8IvTX/xWEkBRowS0ffevRrqkHa/ThDEu86u73FQDg==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
+      "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
@@ -8244,9 +8253,15 @@
       }
     },
     "three": {
-      "version": "0.146.0",
-      "resolved": "https://registry.npmjs.org/three/-/three-0.146.0.tgz",
-      "integrity": "sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A=="
+      "version": "0.148.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.148.0.tgz",
+      "integrity": "sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw=="
+    },
+    "three-mesh-bvh": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.5.21.tgz",
+      "integrity": "sha512-TGXPk7YwtlU5rgQJYA25OT6yAdBMeekfC4BTkGNtTWA5glb2rmEpjxvhZncRQSl73QZir2LFOQT0FjfzgG55xw==",
+      "requires": {}
     },
     "tiny-inflate": {
       "version": "1.0.3",
@@ -8279,10 +8294,27 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
+    "troika-three-text": {
+      "version": "0.47.1",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.47.1.tgz",
+      "integrity": "sha512-/fPRUmxCkXxyUT8k6REC/aWeFzKbNr37ivrkrplSJNb3JcBUXvVt8MT0Ac5wTUvFsYTviYWprYS4/8Laen08WA==",
+      "requires": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.47.0",
+        "troika-worker-utils": "^0.47.0",
+        "webgl-sdf-generator": "1.1.1"
+      }
+    },
+    "troika-three-utils": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.47.0.tgz",
+      "integrity": "sha512-yoVTQxVbpQX3a55giIwqwq6hyJA6oYvq7kaNGwFTeicoWmTZCqqTbytafx1gcuL5umrtw5MYgsxYUSOha+xp5w==",
+      "requires": {}
+    },
     "troika-worker-utils": {
-      "version": "0.46.0",
-      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.46.0.tgz",
-      "integrity": "sha512-bzOx5f2ZBxkFhXtIvDJlLn2AI3bzCkGVbCndl/2dL5QZrwHEKl45OEIilCxYQQWJG1rEbOD9O80tMjoYjw19OA=="
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.47.0.tgz",
+      "integrity": "sha512-PSUc9vunDEkbE23jpgXD3PcF96jQHKjgMjS+4o5g6DEK/ZAPTnldb+FNddhppawfUcuraMFrslo0GmIC8UpEmA=="
     },
     "trough": {
       "version": "2.1.0",
@@ -8462,14 +8494,14 @@
       }
     },
     "vite": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.0.tgz",
-      "integrity": "sha512-ynad+4kYs8Jcnn8J7SacS9vAbk7eMy0xWg6E7bAhS1s79TK+D7tVFGXVZ55S7RNLRROU1rxoKlvZ/qjaB41DGA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.16.3",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.19",
+        "postcss": "^8.4.20",
         "resolve": "^1.22.1",
         "rollup": "^3.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@react-three/drei": "^9.46.4",
-    "@react-three/fiber": "^8.9.1",
+    "@react-three/drei": "^9.51.15",
+    "@react-three/fiber": "^8.10.0",
     "@tauri-apps/api": "^1.2.0",
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.148.0",
     "date-fns": "^2.29.3",
     "fast-fuzzy": "^1.12.0",
     "react": "^18.2.0",
@@ -21,19 +21,19 @@
     "react-markdown": "^8.0.4",
     "recoil": "^0.7.6",
     "remark-gfm": "^3.0.1",
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.2.2",
-    "@types/node": "^18.11.9",
-    "@types/react": "^18.0.25",
-    "@types/react-dom": "^18.0.9",
-    "@vitejs/plugin-react": "^3.0.0",
+    "@types/node": "^18.11.18",
+    "@types/react": "^18.0.26",
+    "@types/react-dom": "^18.0.10",
+    "@vitejs/plugin-react": "^3.0.1",
     "postcss-nesting": "^10.2.0",
-    "stylelint": "^14.16.0",
+    "stylelint": "^14.16.1",
     "stylelint-config-standard": "^29.0.0",
     "typescript": "^4.9.4",
-    "vite": "^4.0.0"
+    "vite": "^4.0.4"
   },
   "prettier": {
     "trailingComma": "es5",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "atk"
@@ -145,11 +145,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "b45ea9b00a7b3f2988e9a65ad3917e62123c38dba709b666506207be96d1790b"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -178,9 +179,9 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
 dependencies = [
  "bzip2-sys",
  "libc",
@@ -223,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "0.13.0"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa0e3586af56b3bfa51fca452bd56e8dbbbd5d8d81cbf0b7e4e35b695b537eb8"
+checksum = "497049e9477329f8f6a559972ee42e117487d01d1e8c2cc9f836ea6fa23a9e1a"
 dependencies = [
  "serde",
  "toml",
@@ -233,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -516,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.2"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "derive_more"
@@ -639,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if",
  "libc",
@@ -755,9 +756,9 @@ checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
 
 [[package]]
 name = "futures-locks"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb42d4fb72227be5778429f9ef5240a38a358925a49f05b5cf702ce7c7e558a"
+checksum = "45ec6fe3675af967e67c5536c0b9d44e34e6c52f86bedc4ea49c5317b8e94d06"
 dependencies = [
  "futures-channel",
  "futures-task",
@@ -888,15 +889,15 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7"
+checksum = "d266041a359dfa931b370ef684cceb84b166beb14f7f0421f4a6a3d0c446d12e"
 dependencies = [
  "cc",
  "libc",
  "log",
  "rustversion",
- "windows 0.32.0",
+ "windows 0.39.0",
 ]
 
 [[package]]
@@ -1008,15 +1009,15 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "globset"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -1133,9 +1134,9 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -1171,7 +1172,7 @@ checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 1.0.4",
+ "itoa 1.0.5",
 ]
 
 [[package]]
@@ -1218,7 +1219,7 @@ dependencies = [
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1268,11 +1269,10 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f1b139373f96a2e0ce3ac931cd01ee973c3c5dd7c40c0c2efe96ad2b6751d"
+checksum = "a05705bc64e0b66a806c3740bd6578ea66051b157ec42dc219c785cbf185aef3"
 dependencies = [
- "crossbeam-utils",
  "globset",
  "lazy_static",
  "log",
@@ -1327,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "itoa"
@@ -1339,9 +1339,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "javascriptcore-rs"
@@ -1406,9 +1406,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
+checksum = "eb3fa5a61630976fc4c353c70297f2e93f1930e3ccee574d59d618ccbd5154ce"
 dependencies = [
  "serde",
  "serde_json",
@@ -1435,9 +1435,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "line-wrap"
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -1738,9 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1760,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.43"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1792,9 +1792,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.78"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1857,9 +1857,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1881,9 +1881,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
+checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
 name = "pathdiff"
@@ -1911,9 +1911,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f400b0f7905bf702f9f3dc3df5a121b16c54e9e8012c082905fdf09a931861a"
+checksum = "0f6e86fb9e7026527a0d46bc308b841d73170ef8f443e1807f6ef88526a816d4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2133,24 +2133,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2428,20 +2428,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.16",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "safemem"
@@ -2534,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 dependencies = [
  "serde",
 ]
@@ -2552,18 +2552,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2572,20 +2572,20 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_repr"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe39d9fbb0ebf5eb2c7cb7e2a47e4f462fad1379f1166b8ae49ad9eae89a7ca"
+checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2599,7 +2599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -2809,9 +2809,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2846,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.15.6"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c8fab9f2ba9a6d7ad55b46f812984b6ab203d774c162163ac297edc9567404b"
+checksum = "ac8e6399427c8494f9849b58694754d7cc741293348a6836b6c8d2c5aa82d8e6"
 dependencies = [
  "bitflags",
  "cairo-rs",
@@ -2903,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18203448b9d4dcad55607eafeda6dc7fe135848e5f567cd8bdade6cafd8b1a85"
+checksum = "5b48820ee3bb6a5031a83b2b6e11f8630bdc5a2f68cb841ab8ebc7a15a916679"
 dependencies = [
  "anyhow",
  "cocoa",
@@ -2929,7 +2929,7 @@ dependencies = [
  "raw-window-handle",
  "regex",
  "rfd",
- "semver 1.0.14",
+ "semver 1.0.16",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2960,7 +2960,7 @@ dependencies = [
  "cargo_toml",
  "heck 0.4.0",
  "json-patch",
- "semver 1.0.14",
+ "semver 1.0.16",
  "serde_json",
  "tauri-utils",
  "winres",
@@ -2981,7 +2981,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.14",
+ "semver 1.0.16",
  "serde",
  "serde_json",
  "sha2",
@@ -3040,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7821c34cf1bd6d89ff46b46a53f3a5050d92afaf2053569f1cc4531167257b24"
+checksum = "36b1c5764a41a13176a4599b5b7bd0881bea7d94dfe45e1e755f789b98317e30"
 dependencies = [
  "cocoa",
  "gtk",
@@ -3076,7 +3076,7 @@ dependencies = [
  "phf 0.10.1",
  "proc-macro2",
  "quote",
- "semver 1.0.14",
+ "semver 1.0.16",
  "serde",
  "serde_json",
  "serde_with",
@@ -3129,18 +3129,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3162,7 +3162,7 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
- "itoa 1.0.4",
+ "itoa 1.0.5",
  "serde",
  "time-core",
  "time-macros",
@@ -3200,9 +3200,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.22.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
+checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3212,7 +3212,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3241,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
@@ -3327,15 +3327,15 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "ucd-trie"
@@ -3351,9 +3351,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3666,19 +3666,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec"
-dependencies = [
- "windows_aarch64_msvc 0.32.0",
- "windows_i686_gnu 0.32.0",
- "windows_i686_msvc 0.32.0",
- "windows_x86_64_gnu 0.32.0",
- "windows_x86_64_msvc 0.32.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
@@ -3772,12 +3759,6 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
@@ -3799,12 +3780,6 @@ name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3832,12 +3807,6 @@ checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
@@ -3859,12 +3828,6 @@ name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3895,12 +3858,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3946,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.22.5"
+version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4906cc7b3c5959893f3984bb60882ec94539eb14622077e6529f5b3d008ee"
+checksum = "4c1ad8e2424f554cc5bdebe8aa374ef5b433feff817aebabca0389961fc7ef98"
 dependencies = [
  "base64",
  "block",
@@ -4059,9 +4016,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.3+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ccf97612ac95f3ccb89b2d7346b345e52f1c3019be4984f0455fb4ba991f8a"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["you"]
 license = ""
 repository = ""
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.59"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -16,7 +16,7 @@ tauri-build = { version = "1.1", features = [] }
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.1", features = ["dialog-all", "fs-read-file", "os-all", "shell-open"] }
+tauri = { version = "1.2", features = ["dialog-all", "fs-read-file", "os-all", "shell-open"] }
 zip = { version = "0.6.3", feature = ["deflate", "time"] }
 reqwest = "0.11.12"
 futures = "0.3.25"

--- a/src/components/screenshots/hooks/useMultiExport.ts
+++ b/src/components/screenshots/hooks/useMultiExport.ts
@@ -1,0 +1,66 @@
+import { open } from "@tauri-apps/api/dialog"
+import { useRecoilCallback } from "recoil"
+import {
+  SingleScreenshotSelectorFamily,
+  VideoJSONSelectorFamily,
+} from "../../../recoil/screenshots/selectors"
+import { Screenshot } from "../../../types"
+import { invokeSaveFile } from "../../../utils/invokes"
+import { useUpscaler } from "./useUpscaler"
+
+export const useMultiExport = () => {
+  const upscaler = useUpscaler()
+
+  return useRecoilCallback(
+    ({ snapshot }) =>
+      async (fileNames: string[]) => {
+        const screenshots = (await Promise.all(
+          fileNames.map((fileName) =>
+            snapshot.getPromise(SingleScreenshotSelectorFamily(fileName))
+          )
+        )) as Screenshot[]
+
+        const screenshotsUpscaled = await Promise.all(
+          screenshots.map(async (screenshot) => {
+            const objUrl = URL.createObjectURL(screenshot.file)
+            const image = new Image()
+            image.src = objUrl
+
+            await new Promise((resolve) => (image.onload = resolve))
+            const videoJson = await snapshot.getPromise(
+              VideoJSONSelectorFamily(`${screenshot.author}.${screenshot.core}`)
+            )
+            const url = upscaler(videoJson, image)
+            const file = await fetch(url)
+              .then((res) => res.arrayBuffer())
+              .then(
+                (buf) =>
+                  new File([buf], screenshot.file_name, { type: "image/png" })
+              )
+            return { ...screenshot, upscaledFile: file }
+          })
+        )
+
+        const saveDir = await open({
+          title: "Save Screenshots",
+          directory: true,
+          multiple: false,
+        })
+
+        if (!saveDir) return
+
+        await Promise.all(
+          screenshotsUpscaled.map(async ({ game, file_name, upscaledFile }) => {
+            const buffer = await upscaledFile.arrayBuffer()
+            const filePath = `${saveDir}/${game
+              .replace(/\.[A-z]*$/, "")
+              .replace(/\s/g, "_")
+              .toLowerCase()
+              .substring(0, 60)}_${file_name}`
+            await invokeSaveFile(filePath, new Uint8Array(buffer))
+          })
+        )
+      },
+    []
+  )
+}

--- a/src/components/screenshots/hooks/useUpscaler.ts
+++ b/src/components/screenshots/hooks/useUpscaler.ts
@@ -1,0 +1,38 @@
+import { useCallback } from "react"
+import { VideoJSON } from "../../../types"
+
+const POCKET_WIDTH = 1600
+const POCKET_HEIGHT = 1440
+
+export const useUpscaler = () => {
+  return useCallback((videoJson: VideoJSON, image: HTMLImageElement) => {
+    const canvas = document.createElement("canvas")
+    const context = canvas.getContext("2d")
+
+    if (!context) throw new Error("Unable to get canvas context")
+
+    const scalarMode = videoJson.video.scaler_modes.find(
+      ({ width, height }) => width === image.width && height === image.height
+    )
+
+    if (scalarMode) {
+      if (scalarMode.aspect_h > scalarMode.aspect_w) {
+        canvas.height = POCKET_HEIGHT
+        canvas.width =
+          POCKET_HEIGHT * (scalarMode.aspect_w / scalarMode.aspect_h)
+      } else {
+        canvas.width = POCKET_WIDTH
+        canvas.height =
+          POCKET_WIDTH * (scalarMode.aspect_h / scalarMode.aspect_w)
+      }
+    } else {
+      canvas.height = image.height * 10
+      canvas.width = image.width * 10
+    }
+
+    context.imageSmoothingEnabled = false
+    context?.drawImage(image, 0, 0, canvas.width, canvas.height)
+
+    return canvas.toDataURL()
+  }, [])
+}

--- a/src/components/screenshots/index.css
+++ b/src/components/screenshots/index.css
@@ -1,4 +1,4 @@
-.screenshots--none{
+.screenshots--none {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -7,56 +7,57 @@
   font-size: 3rem;
   padding: 20px;
   box-sizing: border-box;
-
-  font-family: "Analogue";
+  font-family: Analogue;
   font-smooth: never;
-  -webkit-font-smoothing : none;
+  -webkit-font-smoothing: none;
   text-align: center;
   line-height: 45px;
 }
 
-
-.screenshots__item{
+.screenshots__item {
   overflow: hidden;
   position: relative;
   aspect-ratio: 160 / 144;
   cursor: pointer;
+  border: 2px solid transparent;
+  box-sizing: border-box;
 }
 
-.screenshots__item-image{
+.screenshots__item--selected {
+  border-color: #396cd8;
+}
+
+.screenshots__item-image {
   width: 100%;
   height: 100%;
   object-fit: contain;
-
   background-color: #111;
   image-rendering: pixelated;
 }
-
 
 .screenshots__loading-item {
   height: 190px !important;
   aspect-ratio: 160 / 144;
 }
 
-.screenshots__item-info{
+.screenshots__item-info {
   background-color: var(--info-colour);
   padding: 5px;
   font-size: 0.875rem;
   position: absolute;
   bottom: 0;
   width: 100%;
-
   opacity: 0;
   transform: translateY(80%);
   transition: opacity 0.25s linear, transform 0.2s ease-out;
 }
 
-.screenshots__item:hover .screenshots__item-info{
+.screenshots__item:hover .screenshots__item-info {
   opacity: 0.8;
   transform: translateY(0);
 }
 
-.screenshots__item-info-line{
+.screenshots__item-info-line {
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/components/screenshots/index.tsx
+++ b/src/components/screenshots/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useMemo, useState } from "react"
+import React, { Suspense, useCallback, useMemo, useState } from "react"
 import { useRecoilState, useRecoilValue } from "recoil"
 import { screenshotsListSelector } from "../../recoil/screenshots/selectors"
 import { Screenshot } from "./item"
@@ -11,13 +11,32 @@ import { useSaveScroll } from "../../hooks/useSaveScroll"
 import { Controls } from "../controls"
 import { SearchContextProvider } from "../search/context"
 import { selectedSubviewSelector } from "../../recoil/view/selectors"
+import { useMultiExport } from "./hooks/useMultiExport"
+import { invokeDeleteFiles } from "../../utils/invokes"
+import { useInvalidateFileSystem } from "../../hooks/invalidation"
 
 export const Screenshots = () => {
   const [selected, setSelected] = useRecoilState(selectedSubviewSelector)
   const [searchQuery, setSearchQuery] = useState("")
-  const screenshots = useRecoilValue(screenshotsListSelector)
+  const [selectMode, setSelectMode] = useState(false)
+  const [selectedScreenshots, setSelectedScreenshots] = useState<string[]>([])
 
+  const screenshots = useRecoilValue(screenshotsListSelector)
+  const exportMulti = useMultiExport()
   const { pushScroll, popScroll } = useSaveScroll()
+
+  const invalidateFS = useInvalidateFileSystem()
+
+  const deleteScreenshots = useCallback(
+    async (screenshots: string[]) => {
+      await invokeDeleteFiles(
+        screenshots.map((s) => `Memories/Screenshots/${s}`)
+      )
+      invalidateFS()
+      setSelectedScreenshots([])
+    },
+    [invalidateFS]
+  )
 
   const sortedScreenshots = useMemo(() => {
     return [...screenshots].sort((a, b) => b.localeCompare(a))
@@ -55,6 +74,29 @@ export const Screenshots = () => {
               setSearchQuery(v)
             },
           },
+          selectMode
+            ? {
+                type: "button",
+                text: `Export Selected (${selectedScreenshots.length})`,
+                onClick: () => exportMulti(selectedScreenshots),
+              }
+            : undefined,
+          selectMode
+            ? {
+                type: "button",
+                text: `Delete Selected (${selectedScreenshots.length})`,
+                onClick: () => deleteScreenshots(selectedScreenshots),
+              }
+            : undefined,
+          {
+            type: "checkbox",
+            checked: selectMode,
+            text: "Select",
+            onChange: (checked) => {
+              setSelectedScreenshots([])
+              setSelectMode(checked)
+            },
+          },
         ]}
       />
       <SearchContextProvider query={searchQuery}>
@@ -66,9 +108,20 @@ export const Screenshots = () => {
             >
               <Screenshot
                 fileName={fileName}
+                selected={selectMode && selectedScreenshots.includes(fileName)}
                 onClick={() => {
-                  pushScroll()
-                  setSelected(fileName)
+                  if (selectMode) {
+                    setSelectedScreenshots((s) => {
+                      if (s.includes(fileName)) {
+                        return s.filter((f) => f !== fileName)
+                      } else {
+                        return [...s, fileName]
+                      }
+                    })
+                  } else {
+                    pushScroll()
+                    setSelected(fileName)
+                  }
                 }}
               />
             </Suspense>

--- a/src/components/screenshots/info.tsx
+++ b/src/components/screenshots/info.tsx
@@ -8,6 +8,7 @@ import { useSaveFile } from "../../hooks/saveFile"
 import { Controls } from "../controls"
 import { CoreTag } from "../shared/coreTag"
 import { Loader } from "../loader"
+import { useUpscaler } from "./hooks/useUpscaler"
 
 type ScreenshotInfo = {
   fileName: string
@@ -35,40 +36,14 @@ export const ScreenshotInfo = ({ fileName, onBack }: ScreenshotInfo) => {
 
   const [imageLoaded, setImageLoaded] = useState(false)
 
+  const upscaler = useUpscaler()
+
   const imageSrc = useMemo(() => {
     switch (imageMode) {
       case "raw":
         return URL.createObjectURL(screenshot.file)
       case "upscaled":
-        const canvas = document.createElement("canvas")
-        const context = canvas.getContext("2d")
-
-        if (!context) throw new Error("Unable to get canvas context")
-
-        const scalarMode = videoJson.video.scaler_modes.find(
-          ({ width, height }) =>
-            width === image.width && height === image.height
-        )
-
-        if (scalarMode) {
-          if (scalarMode.aspect_h > scalarMode.aspect_w) {
-            canvas.height = POCKET_HEIGHT
-            canvas.width =
-              POCKET_HEIGHT * (scalarMode.aspect_w / scalarMode.aspect_h)
-          } else {
-            canvas.width = POCKET_WIDTH
-            canvas.height =
-              POCKET_WIDTH * (scalarMode.aspect_h / scalarMode.aspect_w)
-          }
-        } else {
-          canvas.height = image.height * 10
-          canvas.width = image.width * 10
-        }
-
-        context.imageSmoothingEnabled = false
-        context?.drawImage(image, 0, 0, canvas.width, canvas.height)
-
-        return canvas.toDataURL()
+        return upscaler(videoJson, image)
     }
   }, [imageMode, imageLoaded])
 

--- a/src/components/screenshots/item.tsx
+++ b/src/components/screenshots/item.tsx
@@ -5,11 +5,13 @@ import { SearchContextSelfHidingConsumer } from "../search/context"
 
 type ScreenshotProps = {
   fileName: string
+  selected: boolean
   onClick: () => void
 }
 
 export const Screenshot = ({
   fileName,
+  selected,
   onClick,
 }: ScreenshotProps): ReactElement => {
   const screenshot = useRecoilValue(SingleScreenshotSelectorFamily(fileName))
@@ -21,7 +23,13 @@ export const Screenshot = ({
     <SearchContextSelfHidingConsumer
       fields={[screenshot.game, screenshot.platform]}
     >
-      <div className="screenshots__item" role="button" onClick={onClick}>
+      <div
+        className={`screenshots__item screenshots__item--${
+          selected ? "selected" : "not-selected"
+        }`}
+        role="button"
+        onClick={onClick}
+      >
         <img className="screenshots__item-image" src={blob} />
 
         <div className="screenshots__item-info">


### PR DESCRIPTION
<img width="1258" alt="Screenshot 2023-01-07 at 20 28 45" src="https://user-images.githubusercontent.com/2095051/211169277-ea943c98-196f-4110-9c27-9f7d6bce1087.png">

- Resolves https://github.com/neil-morrison44/pocket-sync/issues/38
- Considered having the choice between upscaled vs not upscaled but decided upon always upscaling since the un-upscaled files can just be copied off the SD card (or saved from the single screenshot view)
- ~~Will need to test in windows to make sure the paths work~~ Works fine
- Will be bundling this together with another couple of updates for a release