### PR TITLE
Add support for macOS ARM64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-          - platform: windows-latest
-            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        include:
+          - platform: macos-latest
+            target: universal-apple-darwin
+          - platform: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+          - platform: windows-latest
+            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -27,6 +35,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+      - name: install Rust target (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin 
+          rustup target add x86_64-apple-darwin
+      - name: install Rust target (Windows, Linux)
+        if: matrix.platform != 'macos-latest'
+        run: rustup target add ${{ matrix.target }}
       - name: install app dependencies and build it
         run: npm i && npm run build
 
@@ -41,6 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           releaseId: ${{ steps.get_release.outputs.id }}
+          args: --target ${{ matrix.target }}
   accounce:
     needs: ["build-tauri"]
     runs-on: "ubuntu-latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@66d49884fa48bf8636778f633b2cdc8a67115058
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,4 +50,4 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: bundle
-          path: src-tauri/target/release/bundle/
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
       - name: install app dependencies and build it
         run: npm i && npm run build
-      - uses: tauri-apps/tauri-action@v0
+      - uses: tauri-apps/tauri-action@66d49884fa48bf8636778f633b2cdc8a67115058
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
-          - platform: windows-latest
-            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-20.04, windows-latest]
+        include:
+          - platform: macos-latest
+            target: universal-apple-darwin
+          - platform: ubuntu-20.04
+            target: x86_64-unknown-linux-gnu
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
+          - platform: windows-latest
+            target: aarch64-pc-windows-msvc
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -24,11 +32,21 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev webkit2gtk-4.0 libappindicator3-dev librsvg2-dev patchelf
+      - name: install Rust target (macOS)
+        if: matrix.platform == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin 
+          rustup target add x86_64-apple-darwin
+      - name: install Rust target (Windows, Linux)
+        if: matrix.platform != 'macos-latest'
+        run: rustup target add ${{ matrix.target }}
       - name: install app dependencies and build it
         run: npm i && npm run build
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --target ${{ matrix.target }}
       - uses: actions/upload-artifact@v3
         with:
           name: bundle


### PR DESCRIPTION
This PR adds support for native ARM64 builds for macOS and Windows. The macOS build is a universal build, which combines the x86_64 and ARM64 builds. For Windows, this PR adds a new attribute `target` to the matrix that GitHub Actions runs to produce an ARM64 build.

This should result in better performance for users on ARM64 platforms.