### PR TITLE
Show game extensions

### DIFF
--- a/src/components/games/gameCount.tsx
+++ b/src/components/games/gameCount.tsx
@@ -32,5 +32,7 @@ export const GameCount = ({
     return nonNamedFiles.length
   }, [files, data, extensions])
 
-  return <div>{`${count.toLocaleString()} Games`}</div>
+  return (
+    <div>{`${count.toLocaleString()} ${count === 1 ? "Game" : "Games"}`}</div>
+  )
 }

--- a/src/components/games/item.tsx
+++ b/src/components/games/item.tsx
@@ -73,12 +73,14 @@ export const CoreFolderItem = ({ coreName }: { coreName: string }) => {
             key={platformId}
           />
           <div className="cores__info-blurb">
-            {coreName}
+            <b>{coreName}</b>
             <GameCount
               platformId={platformId}
               coreName={coreName}
               extensions={romsSlot?.extensions || []}
             />
+
+            {`${(romsSlot?.extensions || []).map((e) => `.${e}`).join(", ")}`}
           </div>
         </div>
       ))}


### PR DESCRIPTION
<img width="1301" alt="Screenshot 2023-01-23 at 23 44 04" src="https://user-images.githubusercontent.com/2095051/214177253-9e6744c3-218d-4c3d-ab77-22d93ace8ce3.png">

- Might also show the bios extensions occasionally
- Couldn't think of a good way to represent the "anything goes" cores, like the 2600