### PR TITLE
Improve required files loading experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "2.6.1",
+  "version": "2.6.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/src/install_zip.rs
+++ b/src-tauri/src/install_zip.rs
@@ -234,6 +234,7 @@ async fn start_zip_install_flow(
                 &main_window_c,
             );
         }
+
         emit_finished(None, &main_window_c);
     });
 

--- a/src-tauri/src/progress.rs
+++ b/src-tauri/src/progress.rs
@@ -1,0 +1,59 @@
+pub struct ProgressEmitter<'a> {
+    window: &'a tauri::Window,
+    count: usize,
+    current: usize,
+}
+
+impl ProgressEmitter<'_> {
+    pub fn start(count: usize, window: &tauri::Window) -> ProgressEmitter {
+        window
+            .emit(
+                "progress-start-event",
+                ProgressStartPayload { progress: 0.0 },
+            )
+            .unwrap();
+
+        ProgressEmitter {
+            count: count,
+            current: 0,
+            window: window,
+        }
+    }
+
+    pub fn emit_progress(&mut self, msg: &str) -> () {
+        self.current = self.current + 1;
+        self.window
+            .emit(
+                "progress-event",
+                ProgressPayload {
+                    message: String::from(msg),
+                    progress: self.percent(),
+                },
+            )
+            .unwrap();
+    }
+
+    pub fn end(&self) -> () {
+        self.window
+            .emit("progress-end-event", ProgressEndPayload {})
+            .unwrap();
+    }
+
+    fn percent(&self) -> f32 {
+        (((self.current as f32) / (self.count as f32)) * 100.0) as f32
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+struct ProgressStartPayload {
+    progress: f32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+struct ProgressPayload {
+    message: String,
+    progress: f32,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone)]
+struct ProgressEndPayload {}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "2.6.1"
+    "version": "2.6.2"
   },
   "tauri": {
     "allowlist": {

--- a/src/components/cores/info/installed.tsx
+++ b/src/components/cores/info/installed.tsx
@@ -1,4 +1,4 @@
-import { useRecoilValue } from "recoil"
+import { useRecoilValue, useRecoilValueLoadable } from "recoil"
 import {
   CoreInfoSelectorFamily,
   RequiredFileInfoSelectorFamily,
@@ -31,7 +31,9 @@ type CoreInfoProps = {
 }
 
 export const InstalledCoreInfo = ({ coreName, onBack }: CoreInfoProps) => {
-  const requiredFiles = useRecoilValue(RequiredFileInfoSelectorFamily(coreName))
+  const requiredFilesLoadable = useRecoilValueLoadable(
+    RequiredFileInfoSelectorFamily(coreName)
+  )
   const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
   const uninstall = useUninstallCore()
   const { installCore } = useInstallCore()
@@ -56,7 +58,8 @@ export const InstalledCoreInfo = ({ coreName, onBack }: CoreInfoProps) => {
             text: "Uninstall",
             onClick: () => uninstall(coreName),
           },
-          requiredFiles.length > 0
+          requiredFilesLoadable.state === "hasValue" &&
+          requiredFilesLoadable.getValue().length > 0
             ? {
                 type: "button",
                 text: "Required Files",
@@ -135,10 +138,19 @@ export const InstalledCoreInfo = ({ coreName, onBack }: CoreInfoProps) => {
             </div>
           )}
 
-          <RequiredFiles
-            coreName={coreName}
-            onClick={() => setRequiredFilesOpen(true)}
-          />
+          <Suspense
+            fallback={
+              <div className="core-info__info-row">
+                <strong>{"Required Files:"}</strong>
+                Please wait, checking files...
+              </div>
+            }
+          >
+            <RequiredFiles
+              coreName={coreName}
+              onClick={() => setRequiredFilesOpen(true)}
+            />
+          </Suspense>
 
           {coreInfo.core.metadata.date_release && (
             <div className="core-info__info-row">

--- a/src/components/cores/info/loadRequiredFiles/index.tsx
+++ b/src/components/cores/info/loadRequiredFiles/index.tsx
@@ -23,8 +23,13 @@ export const LoadRequiredFiles = ({
     RequiredFilesWithStatusSelectorFamily(coreName)
   )
   const pocketSyncConfig = useRecoilValue(PocketSyncConfigSelector)
-  const { installRequiredFiles, percent, inProgress, lastMessage } =
-    useInstallRequiredFiles()
+  const {
+    installRequiredFiles,
+    percent,
+    inProgress,
+    lastMessage,
+    remainingTime,
+  } = useInstallRequiredFiles()
 
   const hasArchiveLink = useMemo(
     () =>
@@ -37,7 +42,13 @@ export const LoadRequiredFiles = ({
     <Modal className="load-required-files">
       <h2>{"Required Files"}</h2>
 
-      {inProgress && <Progress percent={percent} message={lastMessage} />}
+      {inProgress && (
+        <Progress
+          percent={percent}
+          message={lastMessage}
+          remainingTime={remainingTime}
+        />
+      )}
 
       {!inProgress && (
         <>

--- a/src/components/cores/info/loadRequiredFiles/index.tsx
+++ b/src/components/cores/info/loadRequiredFiles/index.tsx
@@ -23,7 +23,8 @@ export const LoadRequiredFiles = ({
     RequiredFilesWithStatusSelectorFamily(coreName)
   )
   const pocketSyncConfig = useRecoilValue(PocketSyncConfigSelector)
-  const { installRequiredFiles, progress } = useInstallRequiredFiles()
+  const { installRequiredFiles, percent, inProgress, lastMessage } =
+    useInstallRequiredFiles()
 
   const hasArchiveLink = useMemo(
     () =>
@@ -36,9 +37,9 @@ export const LoadRequiredFiles = ({
     <Modal className="load-required-files">
       <h2>{"Required Files"}</h2>
 
-      {progress && <Progress value={progress.value} max={progress.max} />}
+      {inProgress && <Progress percent={percent} message={lastMessage} />}
 
-      {!progress && (
+      {!inProgress && (
         <>
           <div className="load-required-files__files">
             {requiredFiles.map((r) => (

--- a/src/components/games/instanceJson/index.tsx
+++ b/src/components/games/instanceJson/index.tsx
@@ -1,19 +1,8 @@
-import { path } from "@tauri-apps/api"
 import { listen } from "@tauri-apps/api/event"
 import { useEffect, useState } from "react"
-import { useRecoilCallback, useRecoilValue } from "recoil"
-import { useInvalidateFileSystem } from "../../../hooks/invalidation"
-import { pocketPathAtom } from "../../../recoil/atoms"
-import {
-  BinFilesForCueFileSelectorFamily,
-  cueFilesSelector,
-  instancePackagerCoresListSelector,
-} from "../../../recoil/games/selectors"
-import {
-  invokeRunPackagerForCore,
-  invokeSaveFile,
-} from "../../../utils/invokes"
-import { Loader } from "../../loader"
+import { useRecoilValue } from "recoil"
+import { instancePackagerCoresListSelector } from "../../../recoil/games/selectors"
+import { invokeRunPackagerForCore } from "../../../utils/invokes"
 import { Modal } from "../../modal"
 import { CoreTag } from "../../shared/coreTag"
 

--- a/src/components/progress/index.tsx
+++ b/src/components/progress/index.tsx
@@ -4,13 +4,21 @@ import { ProgressScreen } from "../three/progressScreen"
 type ProgressProps = {
   percent: number
   message?: string | null
+  remainingTime?: string
 }
 
-export const Progress = ({ percent, message }: ProgressProps) => (
-  <Pocket
-    move="back-and-forth"
-    screenMaterial={
-      <ProgressScreen value={percent} max={100} message={message} />
-    }
-  />
+export const Progress = ({
+  percent,
+  message,
+  remainingTime,
+}: ProgressProps) => (
+  <>
+    <Pocket
+      move="back-and-forth"
+      screenMaterial={
+        <ProgressScreen value={percent} max={100} message={message} />
+      }
+    />
+    {remainingTime && <div>{`Remaining Time (approx): ${remainingTime}`}</div>}
+  </>
 )

--- a/src/components/progress/index.tsx
+++ b/src/components/progress/index.tsx
@@ -2,13 +2,15 @@ import { Pocket } from "../three/pocket"
 import { ProgressScreen } from "../three/progressScreen"
 
 type ProgressProps = {
-  value: number
-  max: number
+  percent: number
+  message?: string | null
 }
 
-export const Progress = ({ value, max }: ProgressProps) => (
+export const Progress = ({ percent, message }: ProgressProps) => (
   <Pocket
     move="back-and-forth"
-    screenMaterial={<ProgressScreen value={value} max={max} />}
+    screenMaterial={
+      <ProgressScreen value={percent} max={100} message={message} />
+    }
   />
 )

--- a/src/components/three/progressScreen.tsx
+++ b/src/components/three/progressScreen.tsx
@@ -4,6 +4,7 @@ import { NearestFilter, Texture } from "three"
 type ProgressScreenProps = {
   value: number
   max: number
+  message?: string | null
 }
 
 const SCALE = 4
@@ -16,6 +17,7 @@ const LIGHTEST_GREEN = "#9bbc0f"
 export const ProgressScreen = ({
   value = 33,
   max = 100,
+  message,
 }: ProgressScreenProps) => {
   const [texture, setTexture] = useState<THREE.Texture | null>(null)
 
@@ -40,6 +42,16 @@ export const ProgressScreen = ({
     context.textBaseline = "middle"
     context.fillText(text, canvas.width / 2, canvas.height / 2)
 
+    if (message) {
+      let fontSize = 40
+      do {
+        context.font = `${fontSize * SCALE}px Analogue`
+        fontSize--
+      } while (context.measureText(message).width > canvas.width * 0.8)
+      context.fillStyle = LIGHT_GREEN
+      context.fillText(message, canvas.width / 2, canvas.height * 0.9)
+    }
+
     canvas.toBlob((b) => {
       if (!b) return
       const image = new Image()
@@ -54,7 +66,7 @@ export const ProgressScreen = ({
         setTexture(newTexture)
       }
     })
-  }, [value, max])
+  }, [value, max, message])
 
   return (
     <meshBasicMaterial

--- a/src/components/zipInstall/hooks.ts
+++ b/src/components/zipInstall/hooks.ts
@@ -1,6 +1,7 @@
 import { emit, listen } from "@tauri-apps/api/event"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useInvalidateFileSystem } from "../../hooks/invalidation"
+import { useProgress } from "../../hooks/useProgress"
 import { filterKnownBadFiles } from "../../utils/filterFiles"
 import { FileTreeNode, InstallZipEventPayload } from "./types"
 
@@ -9,6 +10,10 @@ export const useListenForZipInstall = () => {
     useState<null | InstallZipEventPayload>(null)
 
   const invalidateFS = useInvalidateFileSystem()
+
+  // const {inProgress} = useProgress(() => {
+  //   invalidateFS()
+  // })
 
   useEffect(() => {
     const unlisten = listen<InstallZipEventPayload>(

--- a/src/components/zipInstall/index.tsx
+++ b/src/components/zipInstall/index.tsx
@@ -30,7 +30,7 @@ export const ZipInstallInner = ({
     return (
       <Modal>
         <h2>{title}</h2>
-        <Progress value={progress.value} max={progress.max} />
+        <Progress percent={(progress.value / progress.max) * 100} />
       </Modal>
     )
   }

--- a/src/hooks/useInstallRequiredFiles.ts
+++ b/src/hooks/useInstallRequiredFiles.ts
@@ -10,9 +10,11 @@ export const useInstallRequiredFiles = () => {
   const { archive_url } = useRecoilValue(PocketSyncConfigSelector)
   const invalidateFS = useInvalidateFileSystem()
 
-  const { percent, inProgress, lastMessage } = useProgress(() => {
-    invalidateFS()
-  })
+  const { percent, inProgress, lastMessage, remainingTime } = useProgress(
+    () => {
+      invalidateFS()
+    }
+  )
 
   const installRequiredFiles = useCallback(
     async (files: RequiredFileInfo[]) => {
@@ -27,5 +29,11 @@ export const useInstallRequiredFiles = () => {
     [archive_url]
   )
 
-  return { installRequiredFiles, percent, inProgress, lastMessage }
+  return {
+    installRequiredFiles,
+    percent,
+    inProgress,
+    lastMessage,
+    remainingTime,
+  }
 }

--- a/src/hooks/useInstallRequiredFiles.ts
+++ b/src/hooks/useInstallRequiredFiles.ts
@@ -1,36 +1,18 @@
 import { invoke } from "@tauri-apps/api"
-import { listen } from "@tauri-apps/api/event"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 import { useRecoilValue } from "recoil"
 import { PocketSyncConfigSelector } from "../recoil/selectors"
 import { RequiredFileInfo } from "../types"
 import { useInvalidateFileSystem } from "./invalidation"
+import { useProgress } from "./useProgress"
 
 export const useInstallRequiredFiles = () => {
   const { archive_url } = useRecoilValue(PocketSyncConfigSelector)
   const invalidateFS = useInvalidateFileSystem()
 
-  const [progress, setProgress] = useState<{
-    value: number
-    max: number
-  } | null>(null)
-
-  useEffect(() => {
-    const unlisten = listen<{ max: number; value: number }>(
-      "file-progress",
-      ({ payload }) => {
-        setProgress(payload)
-        if (payload.max === payload.value) {
-          invalidateFS()
-          setProgress(null)
-        }
-      }
-    )
-
-    return () => {
-      unlisten.then((l) => l())
-    }
-  }, [])
+  const { percent, inProgress, lastMessage } = useProgress(() => {
+    invalidateFS()
+  })
 
   const installRequiredFiles = useCallback(
     async (files: RequiredFileInfo[]) => {
@@ -45,5 +27,5 @@ export const useInstallRequiredFiles = () => {
     [archive_url]
   )
 
-  return { installRequiredFiles, progress }
+  return { installRequiredFiles, percent, inProgress, lastMessage }
 }

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -1,0 +1,56 @@
+import { listen } from "@tauri-apps/api/event"
+import { useEffect, useMemo, useState } from "react"
+
+export const useProgress = (onEnd?: () => void) => {
+  const [messageLog, setMessageLog] = useState<string[]>([])
+  const lastMessage = useMemo(() => {
+    if (messageLog.length === 0) return null
+    return messageLog[messageLog.length - 1]
+  }, [messageLog])
+
+  const [inProgress, setInProgress] = useState(false)
+  const [percent, setPercent] = useState(0)
+
+  useEffect(() => {
+    const unlisten = listen<ProgressPayload>("progress-start-event", () => {
+      setMessageLog([])
+      setInProgress(true)
+      setPercent(0)
+    })
+    return () => {
+      unlisten.then((l) => l())
+    }
+  }, [])
+
+  useEffect(() => {
+    const unlisten = listen<ProgressPayload>(
+      "progress-event",
+      ({ payload }) => {
+        setMessageLog((bl) => [...bl, payload.message])
+        setPercent(payload.progress)
+      }
+    )
+    return () => {
+      unlisten.then((l) => l())
+    }
+  }, [])
+
+  useEffect(() => {
+    const unlisten = listen<ProgressPayload>("progress-end-event", () => {
+      setInProgress(false)
+      onEnd?.()
+    })
+    return () => {
+      unlisten.then((l) => l())
+    }
+  }, [onEnd])
+
+  return { messageLog, lastMessage, inProgress, percent }
+}
+
+type ProgressPayload = {
+  message: string
+  progress: number
+}
+
+type ProgressEndPayload = {}

--- a/src/hooks/useProgress.ts
+++ b/src/hooks/useProgress.ts
@@ -10,12 +10,31 @@ export const useProgress = (onEnd?: () => void) => {
 
   const [inProgress, setInProgress] = useState(false)
   const [percent, setPercent] = useState(0)
+  const [startTime, setStartTime] = useState(0)
+
+  const remainingTime = useMemo(() => {
+    const currentTime = Date.now()
+    const elapsedTimeMs = currentTime - startTime
+
+    const estimatedTotalTimeMs = elapsedTimeMs / (percent / 100)
+    const remainingTimeMs = estimatedTotalTimeMs - elapsedTimeMs
+    const remainingTimeSec = Math.round(remainingTimeMs / 1000)
+
+    const hours = Math.floor(remainingTimeSec / 3600)
+    const minutes = Math.floor((remainingTimeSec % 3600) / 60)
+    const seconds = remainingTimeSec % 60
+
+    return `${hours.toString().padStart(2, "0")}:${minutes
+      .toString()
+      .padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`
+  }, [startTime, percent])
 
   useEffect(() => {
     const unlisten = listen<ProgressPayload>("progress-start-event", () => {
       setMessageLog([])
       setInProgress(true)
       setPercent(0)
+      setStartTime(Date.now())
     })
     return () => {
       unlisten.then((l) => l())
@@ -45,7 +64,7 @@ export const useProgress = (onEnd?: () => void) => {
     }
   }, [onEnd])
 
-  return { messageLog, lastMessage, inProgress, percent }
+  return { messageLog, lastMessage, inProgress, percent, remainingTime }
 }
 
 type ProgressPayload = {


### PR DESCRIPTION
- Creates a single interface between the TS & the Rust side for detailing any sort of progress, and uses it in the "Required Files" view (zip install still uses the old one, for now)
- No longer waits on checking all the required files hashes etc when opening a core, instead using `<Suspense` to output a little "Please wait" text in that bit of the UI
- Outputs the name of the file & a rough approximation of time left in the loading view