### PR TITLE
Switches to V2 of the inventory API

### DIFF
--- a/src/components/cores/info/notInstalled.tsx
+++ b/src/components/cores/info/notInstalled.tsx
@@ -4,8 +4,10 @@ import { useInstallCore } from "../../../hooks/useInstallCore"
 import { useInventoryItem } from "../../../hooks/useInventoryItem"
 import { DownloadURLSelectorFamily } from "../../../recoil/inventory/selectors"
 import { Controls } from "../../controls"
+import { ErrorBoundary } from "../../errorBoundary"
 import { Link } from "../../link"
 import { Releases } from "./releases"
+import { SponsorLinks } from "./sponsorLinks"
 
 type NotInstalledCoreInfoProps = {
   onBack: () => void
@@ -49,19 +51,39 @@ export const NotInstalledCoreInfo = ({
 
       {inventoryItem && (
         <>
-          <h3 className="core-info__title">{inventoryItem.platform}</h3>
+          <h3 className="core-info__title">{inventoryItem.platform_id}</h3>
           <div className="core-info__info">
-            <div className="core-info__info-row">
-              {inventoryItem.identifier}
-            </div>
-
-            {url && (
+            <div className="core-info__info-grid">
               <div className="core-info__info-row">
-                <strong>{"URL:"}</strong>
-                <Link href={url}>{url}</Link>
+                {inventoryItem.identifier}
               </div>
-            )}
 
+              {url && (
+                <div className="core-info__info-row">
+                  <strong>{"URL:"}</strong>
+                  <Link href={url}>{url}</Link>
+                </div>
+              )}
+
+              {inventoryItem?.sponsor && (
+                <div className="core-info__info-row core-info__info-row--right">
+                  <strong>{"Sponsor:"}</strong>
+                  <ErrorBoundary>
+                    <SponsorLinks links={inventoryItem.sponsor} />
+                  </ErrorBoundary>
+                </div>
+              )}
+
+              <div className="core-info__info-row">
+                <strong>{"Version:"}</strong>
+                {inventoryItem.version}
+              </div>
+
+              <div className="core-info__info-row">
+                <strong>{"Release Date:"}</strong>
+                {inventoryItem.release_date}
+              </div>
+            </div>
             {inventoryItem.repository.platform === "github" && (
               <Releases inventoryItem={inventoryItem} />
             )}

--- a/src/components/cores/item.tsx
+++ b/src/components/cores/item.tsx
@@ -82,19 +82,18 @@ export const NotInstalledCoreItem = ({
   inventoryItem,
   onClick,
 }: NotInstalledCoreItemProps) => {
-  const { platform, identifier } = inventoryItem
+  const { platform_id, identifier, platform } = inventoryItem
 
   return (
     <SearchContextSelfHidingConsumer
-      fields={[platform, identifier, inventoryItem.repository?.owner || ""]}
+      fields={[platform_id, identifier, inventoryItem.repository?.owner || ""]}
       otherFn={({ category }) => {
         if (category === "All") return true
-        const aRelease = inventoryItem?.release || inventoryItem?.prerelease
-        return category === aRelease?.platform.category
+        return category === platform.category
       }}
     >
       <div className="cores__item cores__item--not-installed" onClick={onClick}>
-        <div>{platform}</div>
+        <div>{platform_id}</div>
         <div className="cores__not-installed-item-id">{identifier}</div>
       </div>
     </SearchContextSelfHidingConsumer>

--- a/src/hooks/useUpdateAvailable.ts
+++ b/src/hooks/useUpdateAvailable.ts
@@ -12,16 +12,16 @@ export const useUpdateAvailable = (coreName: string) => {
       ({ identifier }) => identifier === coreName
     )
 
-    if (!inventoryCore?.release) return null
+    if (!inventoryCore?.version) return null
 
-    const { version } = inventoryCore.release
+    const { version } = inventoryCore
     const metadataVersion = coreInfo.core.metadata.version
 
     if (version !== metadataVersion) {
       if (version.includes(metadataVersion)) {
         return null
       }
-      return inventoryCore.release.version
+      return version
     }
 
     return null

--- a/src/recoil/inventory/atoms.ts
+++ b/src/recoil/inventory/atoms.ts
@@ -5,7 +5,7 @@ export const coreInventoryAtom = atom<InventoryJSON>({
   key: "coreInventoryAtom",
   default: (async () => {
     const response = await fetch(
-      "https://openfpga-cores-inventory.github.io/analogue-pocket/api/v1/cores.json"
+      "https://openfpga-cores-inventory.github.io/analogue-pocket/api/v2/cores.json"
     )
     return (await response.json()) as InventoryJSON
   })(),

--- a/src/recoil/inventory/selectors.ts
+++ b/src/recoil/inventory/selectors.ts
@@ -16,30 +16,7 @@ export const DownloadURLSelectorFamily = selectorFamily<string | null, string>({
       if (!inventoryItem || inventoryItem.repository.platform !== "github")
         return null
 
-      const { owner, name: repo } = inventoryItem.repository
-
-      const githubReleaseList = get(
-        GithubReleasesSelectorFamily({ owner, repo })
-      )
-
-      const zips = githubReleaseList[0].assets.filter(({ name }) =>
-        name.endsWith(".zip")
-      )
-
-      if (zips.length === 1) return zips[0].browser_download_url
-      const coreZip = githubReleaseList[0].assets.find(({ name }) => {
-        // hopefully this doesn't get used much
-        const [_, core] = coreName.split(".")
-        const simpleCore = core.replace(/[^\x00-\x7F]/g, "").toLowerCase()
-        const simpleName = name.replace(/[^\x00-\x7F]/g, "").toLowerCase()
-
-        const regex = new RegExp(`[^a-zA-Z0-9]${simpleCore}[^a-zA-Z0-9]`)
-        return name.endsWith(".zip") && regex.test(simpleName)
-      })
-
-      if (!coreZip) return null
-
-      return coreZip.browser_download_url
+      return inventoryItem.download_url
     },
 })
 
@@ -50,12 +27,7 @@ export const cateogryListselector = selector<Category[]>({
     const deviceCategories = get(allCategoriesSelector)
 
     const cateogrySet = new Set([
-      ...inventory.data.flatMap(({ release, prerelease }) => {
-        const releaseDetails = release ?? prerelease
-        if (!releaseDetails) return []
-        const { platform } = releaseDetails
-        return platform.category ? [platform.category] : []
-      }),
+      ...inventory.data.map(({ platform }) => platform.category),
       ...deviceCategories,
     ])
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,23 +131,18 @@ export type InventoryJSON = {
 
 export type InventoryItem = {
   identifier: string
-  platform: PlatformId
+  platform_id: PlatformId
   repository: {
     platform: "github" | string
     owner: string
     name: string
   }
-  release?: InventoryItemRelease
-  prerelease?: InventoryItemRelease
+  release_date: string
+  download_url: string
+  version: Semver | string
   sponsor?: {
     [k: string]: [string] | string
   }
-}
-
-type InventoryItemRelease = {
-  tag_name: Semver | string
-  release_date: string
-  version: Semver | string
   platform: {
     category: string
     name: string


### PR DESCRIPTION
- Closes https://github.com/neil-morrison44/pocket-sync/issues/34 since the JOTEGO & Pram0d cores appear now
- Also closes https://github.com/neil-morrison44/pocket-sync/issues/40 in a roundabout way since the core functionality will no longer hit the github API (assuming that downloads don't count as a request)