### PR TITLE
Fixes the core page reload every ~10 mins

### DIFF
--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useMemo } from "react"
 import { useRecoilValue } from "recoil"
+import { useRecoilSmoothUpdatesFirstSuspend } from "../../hooks/recoilSmoothUpdates"
 import { GithubReleasesSelectorFamily } from "../../recoil/github/selectors"
 import { AppVersionSelector } from "../../recoil/selectors"
 import { ErrorBoundary } from "../errorBoundary"
@@ -11,7 +12,7 @@ import { RandomScreenshotScreen } from "../three/randomScreenshotScreen"
 import "./index.css"
 
 export const About = () => {
-  const selfReleases = useRecoilValue(
+  const selfReleases = useRecoilSmoothUpdatesFirstSuspend(
     GithubReleasesSelectorFamily({
       owner: "neil-morrison44",
       repo: "pocket-sync",

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -1,15 +1,11 @@
 import { Suspense, useMemo } from "react"
 import { useRecoilValue } from "recoil"
 import { GithubReleasesSelectorFamily } from "../../recoil/github/selectors"
-import {
-  AppVersionSelector,
-  PocketSyncConfigSelector,
-} from "../../recoil/selectors"
+import { AppVersionSelector } from "../../recoil/selectors"
 import { ErrorBoundary } from "../errorBoundary"
 import { Link } from "../link"
 import { NewsFeed } from "../newsFeed"
 import { Pocket } from "../three/pocket"
-import { ProgressScreen } from "../three/progressScreen"
 import { RandomScreenshotScreen } from "../three/randomScreenshotScreen"
 
 import "./index.css"

--- a/src/components/autoRefresh/index.tsx
+++ b/src/components/autoRefresh/index.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react"
 import { useSetRecoilState } from "recoil"
 import { coreInventoryAtom } from "../../recoil/inventory/atoms"
-import { newsFeedUpdateAtom } from "../../recoil/newsFeed/atoms"
 
 const INTERVAL_MINS = 10
 

--- a/src/components/cores/info/releases.tsx
+++ b/src/components/cores/info/releases.tsx
@@ -25,6 +25,7 @@ export const Releases = ({ inventoryItem }: ReleasesProps) => {
     GithubReleasesSelectorFamily({
       owner: inventoryItem.repository.owner,
       repo: inventoryItem.repository.name,
+      latest: inventoryItem.version,
     })
   )
 

--- a/src/components/newsFeed/index.tsx
+++ b/src/components/newsFeed/index.tsx
@@ -38,7 +38,7 @@ export const NewsFeed = ({ deepLinks = false }: NewsFeedProps) => {
         {items.map((i) => {
           return (
             <div
-              key={i.title}
+              key={`${i.title}-${i.published.toTimeString()}`}
               className={`news-feed__item news-feed__item--${
                 i.type
               } news-feed__item--${deepLinks ? "link" : "not-link"}`}

--- a/src/hooks/recoilSmoothUpdates.ts
+++ b/src/hooks/recoilSmoothUpdates.ts
@@ -17,3 +17,22 @@ export const useRecoilSmoothUpdates = <T, D>(
   }, [loadable])
   return smoothedValue
 }
+
+export const useRecoilSmoothUpdatesFirstSuspend = <T>(
+  atomOrSelector: RecoilValue<T>
+): T => {
+  const loadable = useRecoilValueLoadable(atomOrSelector)
+  const [smoothedValue, setSmoothedValue] = useState<T>(() => {
+    if (loadable.state !== "hasValue") throw loadable.toPromise()
+    return loadable.getValue()
+  })
+
+  useEffect(() => {
+    const inner = async () => {
+      const value = await loadable.toPromise()
+      setSmoothedValue(value)
+    }
+    inner()
+  }, [loadable])
+  return smoothedValue
+}

--- a/src/recoil/github/selectors.ts
+++ b/src/recoil/github/selectors.ts
@@ -4,13 +4,14 @@ import { coreInventoryAtom } from "../inventory/atoms"
 
 export const GithubReleasesSelectorFamily = selectorFamily<
   GithubRelease[],
-  { owner: string; repo: string }
+  { owner: string; repo: string; latest?: string }
 >({
   key: "GithubReleasesSelectorFamily",
   get:
-    ({ owner, repo }) =>
+    ({ owner, repo, latest }) =>
     async ({ get }) => {
-      get(coreInventoryAtom)
+      if (!latest) get(coreInventoryAtom)
+
       const response = await fetch(
         `https://api.github.com/repos/${owner}/${repo}/releases`
       )

--- a/src/recoil/inventory/selectors.ts
+++ b/src/recoil/inventory/selectors.ts
@@ -1,6 +1,5 @@
 import { selector, selectorFamily } from "recoil"
 import { Category } from "../../types"
-import { GithubReleasesSelectorFamily } from "../github/selectors"
 import { allCategoriesSelector } from "../platforms/selectors"
 import { coreInventoryAtom } from "./atoms"
 


### PR DESCRIPTION
- Now the core'll only reload the github release info if the inventory says there's a new version out