### PR TITLE
Switch to `tokio::fs` methods for a little bit of a speedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "2.8.0"
+    "version": "2.8.1"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
- I _think_ this makes anything which reads files from the Pocket feel a bit snappier, might even help people who plug in via USB