### PR TITLE
Adds auto-reconnect option to settings

### DIFF
--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { useRecoilValue } from "recoil"
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil"
 import {
   PocketSyncConfigSelector,
   skipAlternateAssetsSelector,
@@ -8,6 +8,7 @@ import { Link } from "../link"
 import { useUpdateConfig } from "./hooks/useUpdateConfig"
 
 import "./index.css"
+import { pocketPathAtom, reconnectWhenOpenedAtom } from "../../recoil/atoms"
 
 const ARCHIVE_URL_TEXT = `Please check with your local laws around the downloading of potentially copyrighted (arcade) ROM & BIOS files.
 If you are comfortable with this, copy the following url into the input and hit "save".`
@@ -16,6 +17,10 @@ export const Settings = () => {
   const config = useRecoilValue(PocketSyncConfigSelector)
   const [archiveUrlInput, setArchiveUrl] = useState(config.archive_url || "")
   const skipAlternateAssets = useRecoilValue(skipAlternateAssetsSelector)
+  const setPocketPath = useSetRecoilState(pocketPathAtom)
+  const [reconnectWhenOpened, setReconnectWhenOpened] = useRecoilState(
+    reconnectWhenOpenedAtom
+  )
   const updateConfig = useUpdateConfig()
 
   return (
@@ -75,6 +80,42 @@ export const Settings = () => {
                 updateConfig("skipAlternateAssets", target.checked)
               }
             />
+          </label>
+        </div>
+
+        <div className="settings__row">
+          <h3 className="settings__row-title">
+            {"Reconnect when the app is opened"}
+          </h3>
+          <div className="settings__ramble">
+            Attempt to reconnect to the most recently opened location
+            <pre>{reconnectWhenOpened.path}</pre> upon opening the app, skipping
+            the "Connect to Pocket" button
+          </div>
+          <label className="settings__checkbox">
+            Reconnect when opened
+            <input
+              type="checkbox"
+              checked={reconnectWhenOpened.enable}
+              onChange={({ target }) => {
+                setReconnectWhenOpened((r) => ({
+                  ...r,
+                  enable: target.checked,
+                }))
+              }}
+            />
+          </label>
+        </div>
+
+        <div className="settings__row">
+          <h3 className="settings__row-title">{"Disconnect"}</h3>
+          <div className="settings__ramble">
+            {
+              'Return to the "Connect To Pocket" screen (This doesn\'t eject the SD Card / USB drive)'
+            }
+          </div>
+          <label className="settings__checkbox">
+            <button onClick={() => setPocketPath(null)}>Disconnect</button>
           </label>
         </div>
       </div>

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,4 +1,8 @@
 import { atom } from "recoil"
+import {
+  syncToAppLocalDataEffect,
+  syncToAppLocalDataEffectDefault,
+} from "./effects"
 
 export const pocketPathAtom = atom<string | null>({
   key: "pocketPathAtom",
@@ -23,4 +27,13 @@ export const configInvalidationAtom = atom<number>({
 export const saveFileInvalidationAtom = atom<number>({
   key: "saveFileInvalidationAtom",
   default: Date.now(),
+})
+
+export const reconnectWhenOpenedAtom = atom<{ enable: boolean; path: string }>({
+  key: "reconnectWhenOpenedAtom",
+  default: syncToAppLocalDataEffectDefault("reconnect_when_opened", {
+    enable: false,
+    path: "",
+  }),
+  effects: [syncToAppLocalDataEffect("reconnect_when_opened")],
 })

--- a/src/recoil/effects.ts
+++ b/src/recoil/effects.ts
@@ -9,6 +9,7 @@ import {
 export function syncToAppLocalDataEffect<T>(filename: string): AtomEffect<T> {
   return ({ trigger, onSet, setSelf }) => {
     onSet(async (newValue) => {
+      console.log(`onSet ${newValue}`)
       const text = JSON.stringify(newValue)
       await writeTextFile(`${filename}.json`, text, {
         dir: BaseDirectory.AppLocalData,
@@ -33,5 +34,24 @@ export function syncToAppLocalDataEffect<T>(filename: string): AtomEffect<T> {
 
       read()
     }
+  }
+}
+
+export async function syncToAppLocalDataEffectDefault<T>(
+  filename: string,
+  initialDefault: T
+): Promise<T> {
+  const fileExists = await exists(`${filename}.json`, {
+    dir: BaseDirectory.AppLocalData,
+  })
+
+  if (fileExists) {
+    const text = await readTextFile(`${filename}.json`, {
+      dir: BaseDirectory.AppLocalData,
+    })
+    const value = JSON.parse(text) as T
+    return value
+  } else {
+    return initialDefault
   }
 }

--- a/src/recoil/effects.ts
+++ b/src/recoil/effects.ts
@@ -9,7 +9,6 @@ import {
 export function syncToAppLocalDataEffect<T>(filename: string): AtomEffect<T> {
   return ({ trigger, onSet, setSelf }) => {
     onSet(async (newValue) => {
-      console.log(`onSet ${newValue}`)
       const text = JSON.stringify(newValue)
       await writeTextFile(`${filename}.json`, text, {
         dir: BaseDirectory.AppLocalData,

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -3,6 +3,11 @@ import { RawFeedItem, SaveZipFile } from "../types"
 
 export const invokeOpenPocket = async () => invoke<string | null>("open_pocket")
 
+export const invokeOpenPocketFolder = async (path: string) =>
+  invoke<string | null>("open_pocket_folder", {
+    pocketPath: path,
+  })
+
 export const invokeListFiles = async (path: string) =>
   invoke<string[]>("list_files", {
     path,


### PR DESCRIPTION
- New "Reconnect when the app is opened" option in settings which attempts to reconnect to the last opened path when the app's opened
- Handles things like the path dissapearing etc by just showing the "Connect To Pocket" UI as always
- Also adds a `Disconnect` button to the Settings (which is mostly for my testing but will also be handy to anyone managing multiple SD Cards / Pockets)

closes #100