### PR TITLE
Fix linux file caching error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "3.5.1",
+  "version": "3.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-sync"
-version = "3.5.1"
+version = "3.5.2"
 dependencies = [
  "async-walkdir",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-sync"
-version = "3.5.1"
+version = "3.5.2"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/src/file_cache.rs
+++ b/src-tauri/src/file_cache.rs
@@ -56,9 +56,15 @@ async fn write_to_cache(
 ) -> Option<PathBuf> {
     let file_name = generate_filename_hash(path, modified);
     if !file_cache_dir.exists() {
-        create_dir(&file_cache_dir)
-            .await
-            .expect("failed to create cache dir");
+        println!("Creating filecache dir");
+        if let Err(err) = create_dir(&file_cache_dir).await {
+            println!(
+                "Error creating {} as file cache {}",
+                &file_cache_dir.display(),
+                err
+            );
+            return None;
+        }
     }
     let cache_path = file_cache_dir.join(file_name);
 

--- a/src-tauri/src/file_cache.rs
+++ b/src-tauri/src/file_cache.rs
@@ -56,7 +56,6 @@ async fn write_to_cache(
 ) -> Option<PathBuf> {
     let file_name = generate_filename_hash(path, modified);
     if !file_cache_dir.exists() {
-        println!("Creating filecache dir");
         if let Err(err) = create_dir(&file_cache_dir).await {
             println!(
                 "Error creating {} as file cache {}",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "3.5.1"
+    "version": "3.5.2"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
- Fixes #125
- Unfortunately this'll mean the file cache turns off on affected platforms, but that's a lot better than breaking the whole app
- it's surprisingly hard get an invalid `PathBuf` on MacOS