### PR TITLE
Fixes issue when the folder on the Pocket has a leading slash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "3.5.2",
+  "version": "3.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-sync"
-version = "3.5.2"
+version = "3.5.3"
 dependencies = [
  "async-walkdir",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-sync"
-version = "3.5.2"
+version = "3.5.3"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
   },
   "package": {
     "productName": "Pocket Sync",
-    "version": "3.5.2"
+    "version": "3.5.3"
   },
   "tauri": {
     "allowlist": {


### PR DESCRIPTION
- also improves the response match
- I think you have to create the path on Windows then use it on Mac for this to happen but I'm not 100% sure