### PR TITLE
Adds (tentative) support for `replaced_by` & `replaces` from the inventory

### DIFF
--- a/src/components/cores/info/installed.tsx
+++ b/src/components/cores/info/installed.tsx
@@ -29,6 +29,7 @@ import { RequiredFileInfoSelectorFamily } from "../../../recoil/requiredFiles/se
 import { Trans, useTranslation } from "react-i18next"
 import { archiveBumpAtom } from "../../../recoil/archive/atoms"
 import { currentViewAtom } from "../../../recoil/view/atoms"
+import { useReplacementAvailable } from "../../../hooks/useReplacementAvailable"
 
 type CoreInfoProps = {
   coreName: string
@@ -51,9 +52,7 @@ export const InstalledCoreInfo = ({ coreName, onBack }: CoreInfoProps) => {
   const [coreSettingsOpen, setCoreSettingsOpen] = useState(false)
   const { t } = useTranslation("core_info")
   const setViewAndSubview = useSetRecoilState(currentViewAtom)
-
-  // TODO: Pull this from the inventoryItem once it's there
-  const replacementCore = null
+  const replacementCore = useReplacementAvailable(coreName)
 
   const goToReplacement = useCallback(() => {
     setViewAndSubview({ view: "Cores", selected: replacementCore })

--- a/src/components/cores/version/index.css
+++ b/src/components/cores/version/index.css
@@ -3,10 +3,23 @@
   gap: 5px;
   justify-content: space-between;
   align-items: flex-start;
+  flex-wrap: wrap;
 }
 
-.version__update {
-  background-color: var(--green-colour);
-  padding: 0 10px;
+.version__update, .version__replaced {
+  padding-inline: 4px;
+  padding-inline-end: 8px;
   border-radius: 10px;
+  display: flex;
+  align-items: center;
+
+}
+
+.version__update{
+  background-color: var(--green-colour);
+}
+
+.version__replaced {
+  background-color: var(--red-colour);
+  gap: 2px;
 }

--- a/src/components/cores/version/index.tsx
+++ b/src/components/cores/version/index.tsx
@@ -3,6 +3,8 @@ import { CoreInfoSelectorFamily } from "../../../recoil/selectors"
 
 import "./index.css"
 import { useUpdateAvailable } from "../../../hooks/useUpdateAvailable"
+import { useTranslation } from "react-i18next"
+import { useReplacementAvailable } from "../../../hooks/useReplacementAvailable"
 
 type VersionProps = {
   coreName: string
@@ -11,13 +13,58 @@ type VersionProps = {
 export const Version = ({ coreName }: VersionProps) => {
   const coreInfo = useRecoilValue(CoreInfoSelectorFamily(coreName))
   const updateAvailable = useUpdateAvailable(coreName)
+  const replaceAvailable = useReplacementAvailable(coreName)
+  const { t } = useTranslation("version")
 
   return (
     <div className="version">
       {coreInfo.core.metadata.version}
       {updateAvailable && (
-        <div className="version__update">{updateAvailable}</div>
+        <div
+          className="version__update"
+          title={t("update_alt", { version: updateAvailable })}
+        >
+          <UpArrowIcon />
+          {updateAvailable}
+        </div>
+      )}
+      {replaceAvailable && (
+        <div
+          className="version__replaced"
+          title={t("replaced_alt", { core: replaceAvailable })}
+        >
+          <ReplaceIcon />
+          {t("replaced")}
+        </div>
       )}
     </div>
   )
 }
+
+const UpArrowIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="1.2em"
+    viewBox="0 -960 960 960"
+    width="1.2em"
+  >
+    <path
+      fill="currentcolor"
+      d="M280-160v-60h400v60H280Zm170-170v-356L329-565l-42-42 193-193 193 193-42 42-121-121v356h-60Z"
+    />
+  </svg>
+)
+
+const ReplaceIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="1.2em"
+    viewBox="0 -960 960 960"
+    width="1.2em"
+  >
+    <path
+      fill="currentcolor"
+      d="M196-331q-20-36-28-72.5t-8-74.5q0-131 94.5-225.5T480-798h43l-80-80 39-39 149 149-149 149-40-40 79-79h-41q-107 0-183.5 76.5T220-478q0 29 5.5 55t13.5 49l-43 43ZM476-40 327-189l149-149 39 39-80 80h45q107 0 183.5-76.5T740-479q0-29-5-55t-15-49l43-43q20 36 28.5 72.5T800-479q0 131-94.5 225.5T480-159h-45l80 80-39 39Z"
+    />
+  </svg>
+)

--- a/src/hooks/useReplacementAvailable.ts
+++ b/src/hooks/useReplacementAvailable.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react"
+import { useRecoilValue } from "recoil"
+import { coreInventoryAtom } from "../recoil/inventory/atoms"
+
+export const useReplacementAvailable = (coreName: string) => {
+  const coreInventory = useRecoilValue(coreInventoryAtom)
+
+  return useMemo<string | null>(() => {
+    const inventoryCore = coreInventory.data.find(
+      ({ identifier }) => identifier === coreName
+    )
+    return inventoryCore?.replaced_by || null
+  }, [coreInventory.data, coreName])
+}

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -333,5 +333,10 @@
       "text": "{list}\n\nAssets, Saves etc will be moved over and the old core will be removed.",
       "title": "Replace Cores?"
     }
+  },
+  "version": {
+    "update_alt": "Update {version} available",
+    "replaced_alt": "Replacement core {core} available",
+    "replaced": "Replaced"
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,6 +130,9 @@ export type InventoryJSON = {
 }
 
 export type InventoryItem = {
+  replaced_by?: string
+  replaces?: string[]
+
   identifier: string
   platform_id: PlatformId
   repository: {


### PR DESCRIPTION
- Also includes an icon for the update's version number to make it a bit clearer what that means

<img width="223" alt="Screenshot 2023-08-26 at 18 51 07" src="https://github.com/neil-morrison44/pocket-sync/assets/2095051/a96dfa0f-90cb-44f9-9113-826753cd1d17">

(test SD Card with old versions of things installed)