### PR TITLE
Hide the non-main platform in the "Games" screen & filter out `.sav`s in required files

### DIFF
--- a/src/components/progress/index.tsx
+++ b/src/components/progress/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 import { Pocket } from "../three/pocket"
 import { ProgressScreen } from "../three/progressScreen"
+import { ColourContextProviderFromConfig } from "../three/colourContext"
 
 type ProgressProps = {
   percent: number
@@ -16,7 +17,7 @@ export const Progress = ({
   const { t } = useTranslation("progress")
 
   return (
-    <>
+    <ColourContextProviderFromConfig>
       <Pocket
         move="back-and-forth"
         screenMaterial={
@@ -24,6 +25,6 @@ export const Progress = ({
         }
       />
       {remainingTime && <div>{t("remaining_time", { remainingTime })}</div>}
-    </>
+    </ColourContextProviderFromConfig>
   )
 }

--- a/src/components/settings/index.css
+++ b/src/components/settings/index.css
@@ -61,3 +61,7 @@
     transform: scale(1.2, 1.2);
   }
 }
+
+.settings__checkbox:not(:last-child){
+  margin-block-end: 15px;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export type InstanceDataJSON = {
 }
 
 type DataSlotJSON = {
+  id: number
   name?: string
   required?: boolean
   parameters: number | string

--- a/src/utils/dataSlotsMerge.ts
+++ b/src/utils/dataSlotsMerge.ts
@@ -1,0 +1,12 @@
+import { DataJSON, InstanceDataJSON } from "../types"
+
+export const mergedDataSlots = (
+  coreDataSlots: DataJSON["data"]["data_slots"],
+  instanceDataSlots: InstanceDataJSON["instance"]["data_slots"]
+) => {
+  return instanceDataSlots.map(({ id, ...instanceInfo }) => {
+    const coreSlot = coreDataSlots.find(({ id: coreId }) => coreId === id)
+    if (!coreSlot) return { id, ...instanceInfo }
+    return { ...coreSlot, ...instanceInfo }
+  })
+}

--- a/src/utils/decodeDataParams.ts
+++ b/src/utils/decodeDataParams.ts
@@ -4,8 +4,8 @@ export const decodeDataParams = (rawParams: string | number) => {
   return {
     userReloadable: (parms & 1) === 1,
     coreSpecific: (parms & 2) === 2,
-    nonVolitileFilename: (parms & 0b000000100) === 0b000000100,
-    readOnly: (parms & 0b000001000) === 0b000001000,
+    nonVolitileFilename: (parms & 4) === 4,
+    readOnly: (parms & 8) === 8,
     instanceJSON: (parms & 0b000010000) === 0b000010000,
   }
 }


### PR DESCRIPTION
- Fixes #148
- Fixes #149 (creating folders isn't a bug, but the duplicate non-mains is)

- Thought I'd have a neat way to only mark read only files as "required" but it doesn't work for all cores
- Just hides all the non-main platforms from the Games grid, will deal with doing it properly if multi-platform cores come along legitimately later (and not just to share files between cores)

