### PR TITLE
Allow for user-defined save mapping between the Pocket & the MiSTer

### DIFF
--- a/src-tauri/mister_saves_sync/src/lib.rs
+++ b/src-tauri/mister_saves_sync/src/lib.rs
@@ -107,10 +107,16 @@ impl SaveSyncer for MiSTerSaveSync {
         game: &str,
         _log_channel: &Sender<String>,
     ) -> Result<FoundSave, Box<dyn std::error::Error + Send + Sync>> {
+        let mut all_system_saves: Vec<String> = vec![];
+        let active_platforms = &self.list_platforms().await?;
+
         let mut guard = self.ftp_stream.lock().await;
         let ftp_stream = guard.as_mut().ok_or("ftp_stream not active")?;
 
-        let mut all_system_saves: Vec<String> = vec![];
+        let platforms: Vec<&String> = platforms
+            .into_iter()
+            .filter(|p| active_platforms.iter().any(|ap| ap == *p))
+            .collect();
 
         for mister_system in platforms {
             let system_path = format!("/media/fat/saves/{}", mister_system);
@@ -225,25 +231,4 @@ impl SaveSyncer for MiSTerSaveSync {
 
         return Ok(platforms);
     }
-}
-
-fn pocket_platform_to_mister_system(platform: &str) -> Option<String> {
-    Some(match platform {
-        "gb" | "gbc" => "GAMEBOY",
-        "gg" | "sms" => "SMS",
-        "pce" | "pcecd" => "TGFX16",
-        "gba" => "GBA",
-        "sg1000" => "SG1000",
-        "arduboy" => "Arduboy",
-        "genesis" => "Genesis",
-        "ng" => "NEOGEO",
-        "nes" => "NES",
-        "snes" => "SNES",
-        "supervision" => "SuperVision",
-        "poke_mini" => "PokemonMini",
-        "wonderswan" => "WonderSwan",
-        "gamate" => "Gamate",
-        _ => return None,
-    })
-    .map(String::from)
 }

--- a/src-tauri/mister_saves_sync/src/save_sync.rs
+++ b/src-tauri/mister_saves_sync/src/save_sync.rs
@@ -3,7 +3,7 @@ use std::{io::Read, path::PathBuf};
 
 pub enum FoundSave {
     Found(PathBuf),
-    NotFound(PathBuf),
+    NotFound,
     NotSupported,
 }
 
@@ -20,7 +20,7 @@ pub trait SaveSyncer {
 
     async fn find_save_for(
         &self,
-        platform: &str,
+        platforms: &Vec<String>,
         game: &str,
         log_channel: &tokio::sync::mpsc::Sender<String>,
     ) -> Result<FoundSave, Box<dyn std::error::Error + Send + Sync>>;
@@ -40,4 +40,7 @@ pub trait SaveSyncer {
         &self,
         path: &PathBuf,
     ) -> Result<u64, Box<dyn std::error::Error + Send + Sync>>;
+
+    async fn list_platforms(&self)
+        -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -318,11 +318,8 @@ async fn install_archive_files(
                         .await
                         .unwrap();
 
-                    dbg!(&file);
-
                     if let Some(mtime) = file.mtime {
                         let time = SystemTime::UNIX_EPOCH + Duration::from_millis(mtime);
-                        dbg!(time);
                         set_mtime(&new_file_path, SystemTimeSpec::Absolute(time)).unwrap();
                     }
                 }

--- a/src-tauri/src/save_sync_session.rs
+++ b/src-tauri/src/save_sync_session.rs
@@ -182,6 +182,7 @@ pub async fn start_mister_save_sync_session(
                                     window.emit("mister-save-sync-platform-list", platform_list).unwrap();
                                 },
                                 Ok(OutboundMessage::FoundSave(mister_save_info)) => {
+                                    println!("Emmiting save");
                                     window.emit("mister-save-sync-found-save", mister_save_info).unwrap();
                                 },
                                 Ok(OutboundMessage::MovedSave(transfer)) => {
@@ -310,6 +311,7 @@ async fn find_mister_save(
             }))?;
         }
         Ok(FoundSave::NotFound) => {
+            println!("Save not found");
             outbound_channel.send(OutboundMessage::FoundSave(MiSTerSaveInfo {
                 path: None,
                 timestamp: None,

--- a/src-tauri/src/save_sync_session.rs
+++ b/src-tauri/src/save_sync_session.rs
@@ -21,7 +21,7 @@ struct MiSTerSaveInfo {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct PocketSaveInfo {
     file: String,
-    platform: String,
+    platforms: Vec<String>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -35,12 +35,14 @@ enum IncomingMessage {
     Find(PocketSaveInfo),
     PocketToMiSTer(Transfer),
     MiSTerToPocket(Transfer),
+    ListPlatformsOnMiSTer,
     HeartBeat,
 }
 
 #[derive(Debug, Clone)]
 enum OutboundMessage {
     FoundSave(MiSTerSaveInfo),
+    PlatformList(Vec<String>),
     MovedSave(Transfer),
 }
 
@@ -91,6 +93,13 @@ pub async fn start_mister_save_sync_session(
                 task::spawn(async move {
                     while let Ok(msg) = message_rx.recv().await {
                         match msg {
+                            IncomingMessage::ListPlatformsOnMiSTer => {
+                                let platforms = &mister_syncer.list_platforms().await.unwrap();
+
+                                outbound_message_tx
+                                    .send(OutboundMessage::PlatformList(platforms.clone()))
+                                    .unwrap();
+                            }
                             IncomingMessage::Find(pocket_save_info) => {
                                 let result = find_mister_save(
                                     &outbound_message_tx,
@@ -169,6 +178,9 @@ pub async fn start_mister_save_sync_session(
                           _ = kill_rx.recv() => { break; }
                           msg = outbound_message_rx.recv() => {
                             match msg {
+                                Ok(OutboundMessage::PlatformList(platform_list)) => {
+                                    window.emit("mister-save-sync-platform-list", platform_list).unwrap();
+                                },
                                 Ok(OutboundMessage::FoundSave(mister_save_info)) => {
                                     window.emit("mister-save-sync-found-save", mister_save_info).unwrap();
                                 },
@@ -234,6 +246,16 @@ pub async fn start_mister_save_sync_session(
                 })
             };
 
+            let platform_list_listener = {
+                let message_tx = message_tx.clone();
+                let window = window.clone();
+                window.listen("mister-save-sync-list-platforms", move |_| {
+                    message_tx
+                        .send(IncomingMessage::ListPlatformsOnMiSTer)
+                        .unwrap();
+                })
+            };
+
             {
                 let mut kill_rx = kill_tx.subscribe();
                 task::spawn(async move {
@@ -242,6 +264,7 @@ pub async fn start_mister_save_sync_session(
                     window.unlisten(save_to_pocket_listener);
                     window.unlisten(save_to_mister_listener);
                     window.unlisten(heartbeat_listener);
+                    window.unlisten(platform_list_listener);
                 })
             }
         })
@@ -265,7 +288,7 @@ async fn find_mister_save(
     log_tx: &mpsc::Sender<String>,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     match mister_syncer
-        .find_save_for(&pocket_save_info.platform, &pocket_save_info.file, log_tx)
+        .find_save_for(&pocket_save_info.platforms, &pocket_save_info.file, log_tx)
         .await
     {
         Err(err) => {
@@ -286,9 +309,9 @@ async fn find_mister_save(
                 crc32: Some(crc32),
             }))?;
         }
-        Ok(FoundSave::NotFound(guessed_save_path)) => {
+        Ok(FoundSave::NotFound) => {
             outbound_channel.send(OutboundMessage::FoundSave(MiSTerSaveInfo {
-                path: Some(guessed_save_path),
+                path: None,
                 timestamp: None,
                 pocket_save: pocket_save_info.clone(),
                 crc32: None,

--- a/src/components/saves/misterSync/index.tsx
+++ b/src/components/saves/misterSync/index.tsx
@@ -26,6 +26,7 @@ import { Tip } from "../../tip"
 import { pocketPathAtom } from "../../../recoil/atoms"
 import { MiSTerCredsAtom } from "./recoil/atoms"
 import { useTranslation } from "react-i18next"
+import { SaveMapping } from "./mapping"
 
 type MisterSyncProps = {
   onClose: () => void
@@ -40,6 +41,8 @@ export const MisterSync = ({ onClose }: MisterSyncProps) => {
   const [creds, setCreds] = useRecoilState(MiSTerCredsAtom)
 
   const { t } = useTranslation("mister_sync")
+
+  const [saveMappingOpen, setSaveMappingOpen] = useState(false)
 
   const connect = useCallback(async () => {
     setConnecting(true)
@@ -80,6 +83,11 @@ export const MisterSync = ({ onClose }: MisterSyncProps) => {
             onClick: onClose,
           },
           connected && {
+            type: "button",
+            text: "Save Mapping",
+            onClick: () => setSaveMappingOpen(true),
+          },
+          connected && {
             type: "search",
             text: t("controls.search"),
             value: query,
@@ -87,6 +95,11 @@ export const MisterSync = ({ onClose }: MisterSyncProps) => {
           },
         ]}
       />
+      <Suspense>
+        {saveMappingOpen && (
+          <SaveMapping onClose={() => setSaveMappingOpen(false)} />
+        )}
+      </Suspense>
       <Suspense fallback={<div className="mister-sync__status" />}>
         {selectedSave && <SaveStatus key={selectedSave} path={selectedSave} />}
       </Suspense>

--- a/src/components/saves/misterSync/mapping/index.css
+++ b/src/components/saves/misterSync/mapping/index.css
@@ -1,0 +1,76 @@
+.mister-sync__mapping {
+  display: flex;
+  flex-direction: column;
+}
+
+.mister-sync__mapping-platform-list-header{
+  display: flex;
+  justify-content: space-between;
+  padding-inline-start: 130px;
+  padding-inline-end: 165px;
+  font-size: 1.75rem;
+  font-family: GamePocket;
+  background-color: var(--hover-colour);
+  padding-block: 10px;
+  border-radius: 5px;
+}
+
+.mister-sync__mapping-platform-list {
+  padding-inline: 120px;
+
+  /* padding-block: 12px; */
+  display: grid;
+  grid-template-columns: min-content 1fr min-content;
+  grid-template-rows: repeat(auto-fill, 30px);
+
+  /* grid-template-rows: minmax(100px, 1fr); */
+  overflow: auto;
+  gap: 12px;
+  column-gap: 0;
+  justify-content: center;
+  font-size: 1.15rem;
+  user-select: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-user-select: none;
+  background-color: var(--hover-colour);
+  border-radius: 15px;
+}
+
+.mister-sync__mapping-platform{
+  cursor: grab;
+  border: 1px solid white;
+  border-radius: 5px;
+  padding-inline: 12px;
+  text-align: center;
+  transition: opacity 0.2s linear;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 30px;
+}
+
+.mister-sync__mapping-platform--pocket{
+  grid-column: 1;
+}
+
+.mister-sync__mapping-platform--mister{
+  grid-column: 3;
+}
+
+.mister-sync__mapping-platform-list:has(.mister-sync__mapping-platform:hover) > .mister-sync__mapping-platform {
+  opacity: 0.2;
+}
+
+.mister-sync__mapping-platform--not-new-join{
+  opacity: 0.4;
+}
+
+.mister-sync__mapping-platform:hover{
+  opacity: 1 !important;
+}
+
+.mister-sync__mapping {
+  button:first-of-type {
+    margin-block-start: auto;
+  }
+}

--- a/src/components/saves/misterSync/mapping/index.css
+++ b/src/components/saves/misterSync/mapping/index.css
@@ -7,7 +7,7 @@
   display: flex;
   justify-content: space-between;
   padding-inline-start: 130px;
-  padding-inline-end: 165px;
+  padding-inline-end: 150px;
   font-size: 1.75rem;
   font-family: GamePocket;
   background-color: var(--hover-colour);

--- a/src/components/saves/misterSync/mapping/index.tsx
+++ b/src/components/saves/misterSync/mapping/index.tsx
@@ -1,4 +1,4 @@
-import { useRecoilValue } from "recoil"
+import { useRecoilState, useRecoilValue } from "recoil"
 import { Modal } from "../../../modal"
 import {
   platformListPocketSelector,
@@ -15,18 +15,14 @@ import {
 } from "react"
 
 import "./index.css"
+import { DEFAULT_MISTER_SAVE_MAPPING, saveMappingAtom } from "../recoil/atoms"
 
 type SaveMappingProps = {
   onClose: () => void
 }
 
 export const SaveMapping = ({ onClose }: SaveMappingProps) => {
-  const [joins, setJoins] = useState<{ pocket: string; mister: string }[]>([
-    {
-      pocket: "gba",
-      mister: "GBA",
-    },
-  ])
+  const [joins, setJoins] = useRecoilState(saveMappingAtom)
 
   return (
     <Modal className="mister-sync__mapping">
@@ -37,6 +33,9 @@ export const SaveMapping = ({ onClose }: SaveMappingProps) => {
         </div>
         <PlatformsList joins={joins} setJoins={setJoins} />
       </Suspense>
+      <button onClick={() => setJoins(DEFAULT_MISTER_SAVE_MAPPING)}>
+        Reset To Default
+      </button>
       <button onClick={() => setJoins([])}>clear</button>
       <button onClick={onClose}>closed</button>
     </Modal>
@@ -200,36 +199,39 @@ const PlatformsList = ({ joins, setJoins }: PlatformsListProps) => {
       // joins
 
       for (let index = 0; index < joins.length; index++) {
-        context.save()
         const join = joins[index]
+        context.save()
         context.beginPath()
-        if (hoveredRef.current) {
-          if (
-            hoveredRef.current.platform === join.pocket ||
-            hoveredRef.current.platform === join.mister
-          ) {
-            context.strokeStyle = "white"
-          } else {
-            context.strokeStyle = "rgba(255,255,255,0.1)"
-          }
-        } else {
-          context.strokeStyle = "white"
-        }
-
-        if (newJoinOrigin) {
-          context.strokeStyle = "rgba(255,255,255,0.1)"
-        }
 
         const sY = pocketPositions[join.pocket]
         context.moveTo(0, sY)
 
+        let outlineStyle = "black"
+        let innerStyle = "white"
+
+        if (hoveredRef.current) {
+          if (
+            hoveredRef.current.platform !== join.pocket &&
+            hoveredRef.current.platform !== join.mister
+          ) {
+            innerStyle = "rgba(255,255,255,0.1)"
+            outlineStyle = "rgba(0,0,0,0.1)"
+          }
+        }
+
+        if (newJoinOrigin) {
+          innerStyle = "rgba(255,255,255,0.1)"
+          outlineStyle = "rgba(0,0,0,0.1)"
+        }
+
         const eY = misterPositions[join.mister]
         context.lineTo(cnv.width, eY)
         context.lineWidth = 5
-        context.strokeStyle = "black"
+        context.strokeStyle = outlineStyle
         context.stroke()
+
+        context.strokeStyle = innerStyle
         context.lineWidth = 3
-        context.strokeStyle = "white"
         context.stroke()
 
         context.restore()

--- a/src/components/saves/misterSync/mapping/index.tsx
+++ b/src/components/saves/misterSync/mapping/index.tsx
@@ -16,6 +16,7 @@ import {
 
 import "./index.css"
 import { DEFAULT_MISTER_SAVE_MAPPING, saveMappingAtom } from "../recoil/atoms"
+import { useTranslation } from "react-i18next"
 
 type SaveMappingProps = {
   onClose: () => void
@@ -23,21 +24,22 @@ type SaveMappingProps = {
 
 export const SaveMapping = ({ onClose }: SaveMappingProps) => {
   const [joins, setJoins] = useRecoilState(saveMappingAtom)
+  const { t } = useTranslation("mister_sync")
 
   return (
     <Modal className="mister-sync__mapping">
       <Suspense>
         <div className="mister-sync__mapping-platform-list-header">
-          <div>Pocket</div>
-          <div>MiSTer</div>
+          <div>{t("pocket")}</div>
+          <div>{t("mister")}</div>
         </div>
         <PlatformsList joins={joins} setJoins={setJoins} />
       </Suspense>
       <button onClick={() => setJoins(DEFAULT_MISTER_SAVE_MAPPING)}>
-        Reset To Default
+        {t("mapping.reset")}
       </button>
-      <button onClick={() => setJoins([])}>clear</button>
-      <button onClick={onClose}>closed</button>
+      <button onClick={() => setJoins([])}>{t("mapping.clear")}</button>
+      <button onClick={onClose}>{t("mapping.close")}</button>
     </Modal>
   )
 }

--- a/src/components/saves/misterSync/mapping/index.tsx
+++ b/src/components/saves/misterSync/mapping/index.tsx
@@ -1,0 +1,369 @@
+import { useRecoilValue } from "recoil"
+import { Modal } from "../../../modal"
+import {
+  platformListPocketSelector,
+  platformsListMiSTerSelector,
+} from "../recoil/selectors"
+import {
+  Dispatch,
+  SetStateAction,
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
+
+import "./index.css"
+
+type SaveMappingProps = {
+  onClose: () => void
+}
+
+export const SaveMapping = ({ onClose }: SaveMappingProps) => {
+  const [joins, setJoins] = useState<{ pocket: string; mister: string }[]>([
+    {
+      pocket: "gba",
+      mister: "GBA",
+    },
+  ])
+
+  return (
+    <Modal className="mister-sync__mapping">
+      <Suspense>
+        <div className="mister-sync__mapping-platform-list-header">
+          <div>Pocket</div>
+          <div>MiSTer</div>
+        </div>
+        <PlatformsList joins={joins} setJoins={setJoins} />
+      </Suspense>
+      <button onClick={() => setJoins([])}>clear</button>
+      <button onClick={onClose}>closed</button>
+    </Modal>
+  )
+}
+
+type SourceAndPlatform = {
+  from: "MiSTer" | "Pocket"
+  platform: string
+}
+
+type PlatformsListProps = {
+  joins: { pocket: string; mister: string }[]
+  setJoins: Dispatch<SetStateAction<{ pocket: string; mister: string }[]>>
+}
+
+const PlatformsList = ({ joins, setJoins }: PlatformsListProps) => {
+  const misterPlatforms = useRecoilValue(platformsListMiSTerSelector)
+  const pocketPlatforms = useRecoilValue(platformListPocketSelector)
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+
+  const canvasMousePosition = useRef<{ x: number; y: number }>({ x: 0, y: 0 })
+  const [newJoinOrigin, setNewJoinOrigin] = useState<SourceAndPlatform | null>(
+    null
+  )
+
+  const hoveredRef = useRef<SourceAndPlatform | null>(null)
+
+  const [pocketPositions, setPocketPositions] = useState<
+    Record<string, number>
+  >({})
+  const [misterPositions, setMiSTerPositions] = useState<
+    Record<string, number>
+  >({})
+
+  useLayoutEffect(() => {
+    const setPositions = () => {
+      const container = document.querySelector(
+        ".mister-sync__mapping-platform-list"
+      )
+      const gridRect = container?.getBoundingClientRect()
+      const startY = (gridRect?.y ?? 0) - (container?.scrollTop ?? 0)
+
+      setPocketPositions(
+        Object.fromEntries(
+          Array.from(
+            document.querySelectorAll(".mister-sync__mapping-platform--pocket")
+          ).map((elem) => {
+            const rect = elem.getBoundingClientRect()
+            const y = rect.y + rect.height / 2 - startY
+            return [elem.textContent, y]
+          })
+        )
+      )
+
+      setMiSTerPositions(
+        Object.fromEntries(
+          Array.from(
+            document.querySelectorAll(".mister-sync__mapping-platform--mister")
+          ).map((elem) => {
+            const rect = elem.getBoundingClientRect()
+            const y = rect.y + rect.height / 2 - startY
+            return [elem.textContent, y]
+          })
+        )
+      )
+    }
+
+    if (!canvasRef.current) return
+    setPositions()
+    const resizeObserver = new ResizeObserver(() => setPositions())
+    resizeObserver.observe(canvasRef.current)
+
+    return () => resizeObserver.disconnect()
+  }, [joins])
+
+  useEffect(() => {
+    if (newJoinOrigin) {
+      const handler = () => {
+        if (
+          canvasMousePosition.current.x < 15 &&
+          newJoinOrigin.from === "MiSTer"
+        ) {
+          const y = canvasMousePosition.current.y
+          const closestPlatform = [...pocketPlatforms].sort(
+            (a, b) =>
+              Math.abs(pocketPositions[a] - y) -
+              Math.abs(pocketPositions[b] - y)
+          )[0]
+
+          setJoins((current) => [
+            ...current,
+            { pocket: closestPlatform, mister: newJoinOrigin.platform },
+          ])
+        }
+
+        if (
+          canvasMousePosition.current.x >
+            (canvasRef.current?.width || 0) - 15 &&
+          newJoinOrigin.from === "Pocket"
+        ) {
+          const y = canvasMousePosition.current.y
+          const closestPlatform = [...misterPlatforms].sort(
+            (a, b) =>
+              Math.abs(misterPositions[a] - y) -
+              Math.abs(misterPositions[b] - y)
+          )[0]
+
+          setJoins((current) => [
+            ...current,
+            { pocket: newJoinOrigin.platform, mister: closestPlatform },
+          ])
+        }
+
+        setNewJoinOrigin(null)
+      }
+
+      window.addEventListener("mouseup", handler)
+      window.addEventListener("mouseleave", handler)
+
+      return () => {
+        window.removeEventListener("mouseup", handler)
+        window.removeEventListener("mouseleave", handler)
+      }
+    }
+  }, [
+    misterPlatforms,
+    misterPositions,
+    newJoinOrigin,
+    pocketPlatforms,
+    pocketPositions,
+    setJoins,
+  ])
+
+  useLayoutEffect(() => {
+    if (!canvasRef.current) return
+    const cnv = canvasRef.current
+    const handler = (event: MouseEvent) => {
+      canvasMousePosition.current.x = event.offsetX
+      canvasMousePosition.current.y = event.offsetY
+    }
+
+    cnv.addEventListener("mousemove", handler)
+    return () => cnv.removeEventListener("mousemove", handler)
+  }, [canvasRef])
+
+  useLayoutEffect(() => {
+    if (!canvasRef.current) return
+    const cnv = canvasRef.current
+    const rect = cnv.getBoundingClientRect()
+    cnv.width = rect.width
+    cnv.height = rect.height
+    const abortController = new AbortController()
+
+    const context = cnv.getContext("2d")
+    if (!context) return
+
+    const renderLoop = () => {
+      context.clearRect(0, 0, cnv.width, cnv.height)
+
+      // joins
+
+      for (let index = 0; index < joins.length; index++) {
+        context.save()
+        const join = joins[index]
+        context.beginPath()
+        if (hoveredRef.current) {
+          if (
+            hoveredRef.current.platform === join.pocket ||
+            hoveredRef.current.platform === join.mister
+          ) {
+            context.strokeStyle = "white"
+          } else {
+            context.strokeStyle = "rgba(255,255,255,0.1)"
+          }
+        } else {
+          context.strokeStyle = "white"
+        }
+
+        if (newJoinOrigin) {
+          context.strokeStyle = "rgba(255,255,255,0.1)"
+        }
+
+        const sY = pocketPositions[join.pocket]
+        context.moveTo(0, sY)
+
+        const eY = misterPositions[join.mister]
+        context.lineTo(cnv.width, eY)
+        context.lineWidth = 5
+        context.strokeStyle = "black"
+        context.stroke()
+        context.lineWidth = 3
+        context.strokeStyle = "white"
+        context.stroke()
+
+        context.restore()
+      }
+
+      context.strokeStyle = "white"
+      // in progress join
+      if (newJoinOrigin) {
+        context.save()
+        context.beginPath()
+        const x = newJoinOrigin.from === "Pocket" ? 0 : cnv.width
+        const y =
+          newJoinOrigin.from === "Pocket"
+            ? pocketPositions[newJoinOrigin.platform]
+            : misterPositions[newJoinOrigin.platform]
+
+        context.moveTo(x, y)
+        context.lineTo(
+          canvasMousePosition.current.x,
+          canvasMousePosition.current.y
+        )
+        context.stroke()
+        context.restore()
+      }
+
+      // draw dots
+
+      context.fillStyle = "white"
+      for (let index = 0; index < pocketPlatforms.length; index++) {
+        const element = pocketPlatforms[index]
+
+        const y = pocketPositions[element]
+        context.beginPath()
+        const size = element === newJoinOrigin?.platform ? 6 : 4
+        context.arc(0, y, size, 0, 2 * Math.PI)
+        context.fill()
+      }
+
+      for (let index = 0; index < misterPlatforms.length; index++) {
+        const element = misterPlatforms[index]
+        const y = misterPositions[element]
+        context.beginPath()
+        context.arc(cnv.width, y, 4, 0, 2 * Math.PI)
+        context.fill()
+      }
+
+      context.strokeStyle = "white"
+      context.lineWidth = 3
+
+      if (!abortController.signal.aborted) requestAnimationFrame(renderLoop)
+    }
+
+    renderLoop()
+    return () => abortController.abort()
+  }, [
+    canvasRef,
+    misterPlatforms,
+    newJoinOrigin,
+    pocketPlatforms,
+    joins,
+    pocketPositions,
+    misterPositions,
+  ])
+
+  const pl = pocketPlatforms.length
+  const ml = misterPlatforms.length
+  const pocketOffset = pl < ml * 0.75 ? Math.floor(ml / 2 - pl / 2) : 1
+
+  const canvasSpacerRef = useRef<HTMLDivElement | null>(null)
+
+  return (
+    <div className="mister-sync__mapping-platform-list">
+      {pocketPlatforms.map((platform, index) => (
+        <div
+          key={platform}
+          className={`mister-sync__mapping-platform mister-sync__mapping-platform--pocket ${
+            !newJoinOrigin || newJoinOrigin?.platform === platform
+              ? ""
+              : "mister-sync__mapping-platform--not-new-join"
+          }`}
+          style={{
+            gridRow: index + pocketOffset,
+          }}
+          onMouseDown={() => setNewJoinOrigin({ from: "Pocket", platform })}
+          onMouseEnter={() =>
+            (hoveredRef.current = { from: "Pocket", platform })
+          }
+          onMouseLeave={() => (hoveredRef.current = null)}
+        >
+          {platform}
+        </div>
+      ))}
+      {misterPlatforms.map((platform, index) => (
+        <div
+          key={platform}
+          className={`mister-sync__mapping-platform mister-sync__mapping-platform--mister ${
+            !newJoinOrigin || newJoinOrigin?.platform === platform
+              ? ""
+              : "mister-sync__mapping-platform--not-new-join"
+          } `}
+          style={{
+            gridRow: index + 1,
+          }}
+          onMouseDown={() => setNewJoinOrigin({ from: "MiSTer", platform })}
+          onMouseEnter={() =>
+            (hoveredRef.current = { from: "MiSTer", platform })
+          }
+          onMouseLeave={() => (hoveredRef.current = null)}
+        >
+          {platform}
+        </div>
+      ))}
+      <div
+        ref={canvasSpacerRef}
+        style={{
+          position: "relative",
+          gridColumn: 2,
+          gridRow: `1 / ${
+            Math.max(pocketPlatforms.length, misterPlatforms.length) + 1
+          }`,
+        }}
+      >
+        <canvas
+          ref={canvasRef}
+          style={{
+            display: "block",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: "100%",
+          }}
+        ></canvas>
+      </div>
+    </div>
+  )
+}

--- a/src/components/saves/misterSync/recoil/atoms.ts
+++ b/src/components/saves/misterSync/recoil/atoms.ts
@@ -27,3 +27,60 @@ export const MiSTerCredsAtom = atom<{
   },
   effects: [syncToAppLocalDataEffect("mister_creds")],
 })
+
+export type MiSTerSaveJoin = { pocket: string; mister: string }
+
+export const DEFAULT_MISTER_SAVE_MAPPING = [
+  {
+    pocket: "gb",
+    mister: "GAMEBOY",
+  },
+  {
+    pocket: "gbc",
+    mister: "GAMEBOY",
+  },
+  {
+    pocket: "gba",
+    mister: "GBA",
+  },
+  {
+    pocket: "gg",
+    mister: "SMS",
+  },
+  {
+    pocket: "sms",
+    mister: "SMS",
+  },
+  {
+    pocket: "pce",
+    mister: "TGFX16",
+  },
+  {
+    pocket: "pcecd",
+    mister: "TGFX16",
+  },
+  {
+    pocket: "pcecd",
+    mister: "TGFX16",
+  },
+  {
+    pocket: "sg1000",
+    mister: "SG1000",
+  },
+  { pocket: "arduboy", mister: "Arduboy" },
+  { pocket: "genesis", mister: "Genesis" },
+  { pocket: "genesis", mister: "MegaDrive" },
+  { pocket: "ng", mister: "NEOGEO" },
+  { pocket: "nes", mister: "NES" },
+  { pocket: "snes", mister: "SNES" },
+  { pocket: "supervision", mister: "SuperVision" },
+  { pocket: "poke_mini", mister: "PokemonMini" },
+  { pocket: "wonderswan", mister: "WonderSwan" },
+  { pocket: "gamete", mister: "Gamate" },
+] satisfies MiSTerSaveJoin[]
+
+export const saveMappingAtom = atom<MiSTerSaveJoin[]>({
+  key: "saveMappingAtom",
+  default: DEFAULT_MISTER_SAVE_MAPPING,
+  effects: [syncToAppLocalDataEffect("mister_save_mapping")],
+})

--- a/src/components/saves/misterSync/recoil/selectors.ts
+++ b/src/components/saves/misterSync/recoil/selectors.ts
@@ -1,6 +1,6 @@
 import { emit, listen } from "@tauri-apps/api/event"
-import { selectorFamily } from "recoil"
-import { invokeFileMetadata } from "../../../../utils/invokes"
+import { selector, selectorFamily } from "recoil"
+import { invokeFileMetadata, invokeListFiles } from "../../../../utils/invokes"
 import { SavesInvalidationAtom } from "./atoms"
 
 type MiSTerSaveInfo = {
@@ -56,4 +56,31 @@ export const FileMetadataSelectorFamily = selectorFamily<
       const info = await invokeFileMetadata(`Saves/${filePath}`)
       return info
     },
+})
+
+export const platformsListMiSTerSelector = selector<string[]>({
+  key: "platformsListMiSTerSelector",
+  get: async () => {
+    emit("mister-save-sync-list-platforms")
+
+    return new Promise<string[]>((resolve, _reject) => {
+      const unlisten = listen<string[]>(
+        "mister-save-sync-platform-list",
+        ({ payload }) => {
+          const sorted = [...payload].sort((a, b) => a.localeCompare(b))
+          resolve(sorted)
+          unlisten.then((l) => l())
+        }
+      )
+    })
+  },
+})
+
+export const platformListPocketSelector = selector<string[]>({
+  key: "platformListPocketSelector",
+  get: async () => {
+    const platforms = await invokeListFiles("Saves")
+    const sorted = [...platforms].sort((a, b) => a.localeCompare(b))
+    return sorted
+  },
 })

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -195,7 +195,7 @@
     "tip_1": "The MiSTer's FTP must be turned on",
     "tip_2": "Make sure the save is compatible between Pocket & MiSTer before transfer",
     "tip_3": "The Game must be named exactly the same on the Pocket and the MiSTer for the save to be found",
-    "unsupported": "{platform} is not supported\n(open a github issue if it should be)"
+    "unsupported": "{platform} is not mapped"
   },
   "news_feed": {
     "last_updated": "Last updated <1></1>",

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -286,7 +286,12 @@
     "not_found": "Not found",
     "oldest_backup": "Oldest Backup: {date, date, long}, {date, time, short}",
     "remove": "Remove Location",
-    "view_saves": "View Saves"
+    "view_saves": "View Saves",
+    "mapping": {
+      "close": "Close",
+      "clear": "Clear",
+      "reset": "Reset to default"
+    }
   },
   "screenshot_info": {
     "controls": {

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -195,7 +195,12 @@
     "tip_1": "The MiSTer's FTP must be turned on",
     "tip_2": "Make sure the save is compatible between Pocket & MiSTer before transfer",
     "tip_3": "The Game must be named exactly the same on the Pocket and the MiSTer for the save to be found",
-    "unsupported": "{platform} is not mapped"
+    "unsupported": "{platform} is not mapped",
+    "mapping": {
+      "close": "Close",
+      "clear": "Clear",
+      "reset": "Reset to default"
+    }
   },
   "news_feed": {
     "last_updated": "Last updated <1></1>",
@@ -286,12 +291,7 @@
     "not_found": "Not found",
     "oldest_backup": "Oldest Backup: {date, date, long}, {date, time, short}",
     "remove": "Remove Location",
-    "view_saves": "View Saves",
-    "mapping": {
-      "close": "Close",
-      "clear": "Clear",
-      "reset": "Reset to default"
-    }
+    "view_saves": "View Saves"
   },
   "screenshot_info": {
     "controls": {

--- a/src/i18n/locales/es/index.json
+++ b/src/i18n/locales/es/index.json
@@ -195,7 +195,12 @@
     "tip_1": "El FTP del MiSTer debe estar activado",
     "tip_2": "Asegúrese de que el guardado sea compatible entre Pocket y MiSTer antes de realizar la transferencia.",
     "tip_3": "El juego debe tener exactamente el mismo nombre en el Pocket y en MiSTer para poder encontrar el guardado.",
-    "unsupported": "{platform} no es compatible"
+    "unsupported": "{platform} no es compatible",
+    "mapping": {
+      "close": "Cerrar",
+      "clear": "Borrar",
+      "reset": "Restablecer valores predeterminados"
+    }
   },
   "news_feed": {
     "last_updated": "Última actualización <1></1>",

--- a/src/i18n/locales/es/index.json
+++ b/src/i18n/locales/es/index.json
@@ -195,7 +195,7 @@
     "tip_1": "El FTP del MiSTer debe estar activado",
     "tip_2": "Asegúrese de que el guardado sea compatible entre Pocket y MiSTer antes de realizar la transferencia.",
     "tip_3": "El juego debe tener exactamente el mismo nombre en el Pocket y en MiSTer para poder encontrar el guardado.",
-    "unsupported": "{platform} no es compatible\n(abra un problema de github si así debe ser)"
+    "unsupported": "{platform} no es compatible"
   },
   "news_feed": {
     "last_updated": "Última actualización <1></1>",


### PR DESCRIPTION
- Closes #132
- New UI to map the folders with saves on them in the Pocket to the folders with saves in them on the MiSTer
<img width="1428" alt="Screenshot 2023-10-14 at 16 03 53" src="https://github.com/neil-morrison44/pocket-sync/assets/2095051/3e33295f-01f6-4049-964b-56f20f0431cb">

- If a pocket platform is mapped to multiple MiSTer cores then it'll look for the save in all of them

- Then you the option of where on the MiSTer to move a Pocket Save to
<img width="1428" alt="Screenshot 2023-10-14 at 16 05 18" src="https://github.com/neil-morrison44/pocket-sync/assets/2095051/02ed53fd-30b4-423d-a227-a98f37f261fc">

- Doesn't support moving a new save from the MiSTer to the Pocket, but this never did. Since the Pocket cares more about the save being in the right folder etc
