### PR TITLE
Be more defensive when downloading github releases

### DIFF
--- a/src/recoil/palettes/selectors.tsx
+++ b/src/recoil/palettes/selectors.tsx
@@ -89,7 +89,7 @@ export const palleteZipURLSelector = selector<string | null>({
       { method: "GET", headers: { "User-Agent": `Pocket Sync` } }
     )
 
-    const zip = response.data.assets.find((asset) =>
+    const zip = (response?.data?.assets || []).find((asset) =>
       asset.name.endsWith(".zip")
     )
 

--- a/src/recoil/platforms/selectors.ts
+++ b/src/recoil/platforms/selectors.ts
@@ -148,6 +148,8 @@ const ImagePackBlobSelectorFamily = selectorFamily<Blob | null, ImagePack>({
         )
       ).json()) as { assets: [{ name: string; browser_download_url: string }] }
 
+      if (!latestRelease?.assets) return null
+
       const downloadURL = latestRelease.assets.find(({ name }) => {
         if (!name.endsWith(".zip")) return false
         if (variant)


### PR DESCRIPTION
- Fixes https://github.com/neil-morrison44/pocket-sync/issues/248 by ignoring image / data packs without files attached