### PR TITLE
Restore previous behaviour of only showing files marked as Required

### DIFF
--- a/src-tauri/src/required_files/mod.rs
+++ b/src-tauri/src/required_files/mod.rs
@@ -130,7 +130,10 @@ impl DataSlotFile {
             && (self.name.contains("bios")
                 || self.name.contains("beta.bin")
                 || self.required
-                || true)
+                // Setthing this to `true` has it try to download all files
+                // even if they're not marked as required
+                // can't find why that made sense
+                || false)
     }
 }
 

--- a/src/components/about/index.css
+++ b/src/components/about/index.css
@@ -72,7 +72,7 @@
     gap: 5px;
     will-change: opacity, background-color;
     opacity: 0.8;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     text-decoration: none;
     background-color: rgb(255 255 255 / 10%);
     padding-inline: 5px;

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -1,10 +1,7 @@
 import { ReactNode, Suspense, useLayoutEffect, useMemo, useRef } from "react"
 import { useRecoilValue, useSetRecoilState } from "recoil"
 import { useRecoilSmoothUpdatesFirstSuspend } from "../../hooks/recoilSmoothUpdates"
-import {
-  GithubReleasesSelectorFamily,
-  sponsorCountSelector,
-} from "../../recoil/github/selectors"
+import { GithubReleasesSelectorFamily } from "../../recoil/github/selectors"
 import { AppVersionSelector } from "../../recoil/selectors"
 import { ErrorBoundary } from "../errorBoundary"
 import { Link } from "../link"
@@ -19,6 +16,7 @@ import { StaticScreen } from "../three/staticScreen"
 import { useTranslation } from "react-i18next"
 import { semverCompare } from "../../utils/semverCompare"
 import { ColourContextProviderFromConfig } from "../three/colourContext"
+import { sponsorCountAtom } from "../../recoil/github/atoms"
 
 export const About = () => {
   const selfReleases = useRecoilSmoothUpdatesFirstSuspend(
@@ -30,7 +28,7 @@ export const About = () => {
 
   const { t } = useTranslation("about")
   const AppVersion = useRecoilValue(AppVersionSelector)
-  const sponsorCount = useRecoilValue(sponsorCountSelector)
+
   const firmwareUpdateAvailable = useRecoilValue(updateAvailableSelector)
 
   const updateAvailable = useMemo(() => {
@@ -43,22 +41,9 @@ export const About = () => {
   return (
     <div className="about">
       <div className="about__sponsor">
-        <Link href={"https://github.com/sponsors/neil-morrison44"}>
-          <svg
-            width="1.47em"
-            height="1.44em"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 98 96"
-          >
-            <path
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
-              fill="white"
-            />
-          </svg>
-          {t("sponsor_link", { count: sponsorCount })}
-        </Link>
+        <Suspense>
+          <SponsorLink />
+        </Suspense>
       </div>
       <div className="about__top">
         <div className="about__title">
@@ -104,6 +89,30 @@ export const About = () => {
         </Suspense>
       </div>
     </div>
+  )
+}
+
+const SponsorLink = () => {
+  const sponsorCount = useRecoilValue(sponsorCountAtom)
+  const { t } = useTranslation("about")
+
+  return (
+    <Link href={"https://github.com/sponsors/neil-morrison44"}>
+      <svg
+        width="1.47em"
+        height="1.44em"
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 98 96"
+      >
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+          fill="white"
+        />
+      </svg>
+      {t("sponsor_link", { count: sponsorCount })}
+    </Link>
   )
 }
 

--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -1,7 +1,10 @@
 import { ReactNode, Suspense, useLayoutEffect, useMemo, useRef } from "react"
 import { useRecoilValue, useSetRecoilState } from "recoil"
 import { useRecoilSmoothUpdatesFirstSuspend } from "../../hooks/recoilSmoothUpdates"
-import { GithubReleasesSelectorFamily } from "../../recoil/github/selectors"
+import {
+  GithubReleasesSelectorFamily,
+  sponsorCountSelector,
+} from "../../recoil/github/selectors"
 import { AppVersionSelector } from "../../recoil/selectors"
 import { ErrorBoundary } from "../errorBoundary"
 import { Link } from "../link"
@@ -27,6 +30,7 @@ export const About = () => {
 
   const { t } = useTranslation("about")
   const AppVersion = useRecoilValue(AppVersionSelector)
+  const sponsorCount = useRecoilValue(sponsorCountSelector)
   const firmwareUpdateAvailable = useRecoilValue(updateAvailableSelector)
 
   const updateAvailable = useMemo(() => {
@@ -53,7 +57,7 @@ export const About = () => {
               fill="white"
             />
           </svg>
-          {t("sponsor_link")}
+          {t("sponsor_link", { count: sponsorCount })}
         </Link>
       </div>
       <div className="about__top">

--- a/src/i18n/locales/de/index.json
+++ b/src/i18n/locales/de/index.json
@@ -3,7 +3,7 @@
     "app_name": "Pocket Sync",
     "new_firmware": "Neue Pocket-Firmware v{version} verfügbar",
     "update_available": "Aktualisierung verfügbar! {version}",
-    "sponsor_link": "Sponsor über GitHub"
+    "sponsor_link": "Schließen Sie sich {count, number} Personen beim Sponsoring über GitHub an"
   },
   "app": {
     "app_name": "Pocket Sync",

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -3,7 +3,7 @@
     "app_name": "Pocket Sync",
     "new_firmware": "New Pocket Firmware v{version} available",
     "update_available": "Update Available! {version}",
-    "sponsor_link": "Sponsor via GitHub"
+    "sponsor_link": "Join {count, number} people in sponsoring via GitHub"
   },
   "app": {
     "app_name": "Pocket Sync",

--- a/src/i18n/locales/es/index.json
+++ b/src/i18n/locales/es/index.json
@@ -3,7 +3,7 @@
     "app_name": "Pocket Sync",
     "new_firmware": "Nuevo Pocket Firmware v{version} disponible",
     "update_available": "¡Actualización disponible! {version}",
-    "sponsor_link": "Patrocinador a través de GitHub"
+    "sponsor_link": "Únase a {count, number} personas para patrocinar a través de GitHub"
   },
   "app": {
     "app_name": "Pocket Sync",

--- a/src/i18n/locales/fr/index.json
+++ b/src/i18n/locales/fr/index.json
@@ -2,7 +2,7 @@
   "about": {
     "new_firmware": "Nouveau Pocket Firmware v{version} disponible",
     "update_available": "Mise à jour disponible ! {version}",
-    "sponsor_link": "Parrainer via GitHub"
+    "sponsor_link": "Rejoignez {count, number} personnes en parrainage via GitHub"
   },
   "app": {
     "connect_button": "Connecter la Pocket / Carte SD",

--- a/src/i18n/locales/zh/index.json
+++ b/src/i18n/locales/zh/index.json
@@ -3,7 +3,7 @@
     "app_name": "Pocket Sync",
     "new_firmware": "发现新的Pocket固件 v{version}",
     "update_available": "软件有更新! {version}",
-    "sponsor_link": "通过 GitHub 赞助"
+    "sponsor_link": "通过 GitHub 与 {count, number} 人一起赞助"
   },
   "app": {
     "app_name": "Pocket Sync",

--- a/src/recoil/github/atoms.ts
+++ b/src/recoil/github/atoms.ts
@@ -1,0 +1,30 @@
+import { atom } from "recoil"
+
+const INTERVAL_MINS = 15
+
+const getSponsorCount = async () => {
+  try {
+    const response = await fetch(
+      `https://ghs.vercel.app/sponsors/neil-morrison44`
+    )
+    const { sponsors } = (await response.json()) as { sponsors: string[] }
+    return sponsors.length
+  } catch (err) {
+    return 0
+  }
+}
+
+export const sponsorCountAtom = atom<number>({
+  key: "sponsorCountAtom",
+  default: getSponsorCount(),
+  effects: [
+    ({ setSelf }) => {
+      const interval = setInterval(async () => {
+        const newCount = await getSponsorCount()
+        setSelf(newCount)
+      }, INTERVAL_MINS * 60 * 1000)
+
+      return () => clearInterval(interval)
+    },
+  ],
+})

--- a/src/recoil/github/selectors.ts
+++ b/src/recoil/github/selectors.ts
@@ -1,5 +1,5 @@
 import { GithubRelease } from "../../types"
-import { selectorFamily } from "recoil"
+import { selector, selectorFamily } from "recoil"
 import { coreInventoryAtom } from "../inventory/atoms"
 
 export const GithubReleasesSelectorFamily = selectorFamily<
@@ -32,4 +32,19 @@ export const GithubReleasesSelectorFamily = selectorFamily<
 
       return (await response.json()) as GithubRelease[]
     },
+})
+
+export const sponsorCountSelector = selector({
+  key: "sponsorCountSelector",
+  get: async () => {
+    try {
+      const response = await fetch(
+        `https://ghs.vercel.app/sponsors/neil-morrison44`
+      )
+      const { sponsors } = (await response.json()) as { sponsors: string[] }
+      return sponsors.length
+    } catch (err) {
+      return 0
+    }
+  },
 })

--- a/src/recoil/github/selectors.ts
+++ b/src/recoil/github/selectors.ts
@@ -1,5 +1,5 @@
 import { GithubRelease } from "../../types"
-import { selector, selectorFamily } from "recoil"
+import { selectorFamily } from "recoil"
 import { coreInventoryAtom } from "../inventory/atoms"
 
 export const GithubReleasesSelectorFamily = selectorFamily<
@@ -32,19 +32,4 @@ export const GithubReleasesSelectorFamily = selectorFamily<
 
       return (await response.json()) as GithubRelease[]
     },
-})
-
-export const sponsorCountSelector = selector({
-  key: "sponsorCountSelector",
-  get: async () => {
-    try {
-      const response = await fetch(
-        `https://ghs.vercel.app/sponsors/neil-morrison44`
-      )
-      const { sponsors } = (await response.json()) as { sponsors: string[] }
-      return sponsors.length
-    } catch (err) {
-      return 0
-    }
-  },
 })


### PR DESCRIPTION
- Not sure what edge case required showing them all, if there is one hopefully someone raises it as a bug soon
- Has been causing confusion & I don't want to maintain a list of files which aren't actually required
- Also shows the current sponsorship count in the link, since, you know. 