### PR TITLE
filter directories out of list_files command

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -185,11 +185,15 @@ async fn list_files(
     let mut results: Vec<_> = Vec::new();
 
     while let Ok(Some(entry)) = paths.next_entry().await {
-        let file_name = entry.file_name();
-        let file_name = file_name.to_str().unwrap();
+        let file_type = entry.file_type().await.unwrap();
 
-        if !file_name.starts_with(".") {
-            results.push(String::from(file_name))
+        if file_type.is_file() {
+            let file_name = entry.file_name();
+            let file_name = file_name.to_str().unwrap();
+
+            if !file_name.starts_with(".") {
+                results.push(String::from(file_name))
+            }
         }
     }
 


### PR DESCRIPTION
This addresses https://github.com/neil-morrison44/pocket-sync/issues/261

If you'd rather a different approach to fix this then feel free to close this, but this replicates the functionality the Pocket has where any screenshots in a folder are just ignored and not shown.

Don't think this negatively affects any of the other uses of `invokeListFiles` but would appreciate you double checking.