### PR TITLE
Add `pt` (Portuguese) translations

### DIFF
--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,14 +1,7 @@
 {
   "$schema": "https://inlang.com/schema/project-settings",
   "sourceLanguageTag": "en",
-  "languageTags": [
-    "en",
-    "en-US",
-    "es",
-    "zh",
-    "de",
-    "fr"
-  ],
+  "languageTags": ["en", "en-US", "es", "zh", "de", "fr", "pt"],
   "modules": [
     "https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@4/dist/index.js",
     "https://cdn.jsdelivr.net/npm/@inlang/message-lint-rule-empty-pattern@latest/dist/index.js",

--- a/src/i18n/locales/pt/index.json
+++ b/src/i18n/locales/pt/index.json
@@ -1,0 +1,492 @@
+{
+  "about": {
+    "app_name": "Pocket Sync",
+    "new_firmware": "Nova versão do firmware Pocket v{version} disponível",
+    "update_available": "Atualização Disponível! {version}",
+    "sponsor_link": "Junte-se a {count, number} pessoas a patrocinar via GitHub"
+  },
+  "app": {
+    "app_name": "Pocket Sync",
+    "connect_button": "Conectar ao Pocket / Cartão SD",
+    "not_pocket_tip": "Essa pasta não parece ser o sistema de arquivos do Pocket. O cartão SD deve ser inicializado pelo Pocket pelo menos uma vez."
+  },
+  "clean_files": {
+    "close_button": "Fechar",
+    "delete_files_button": "Eliminar Arquivos",
+    "files_found": "{count, plural, =0 {Nenhum arquivo limpável} one {# arquivo limpável} other {# arquivos limpáveis}} encontrado",
+    "title": "Limpar Arquivos"
+  },
+  "update_all": {
+    "title": "Atualizar Tudo",
+    "heading": {
+      "update": "Atualizar",
+      "required_files": "Instalar Arquivos Necessários",
+      "platform_files": "Substituir Arquivos da Plataforma"
+    },
+    "buttons": {
+      "update": "Atualizar {count, plural, =0 {nenhum} one {# núcleo selecionado} other {# núcleos selecionados}}",
+      "close": "Fechar"
+    },
+    "update": {
+      "title": "Atualizando {coreName}: {step, select, core { atualizando núcleo... } files { baixando Arquivos Necessários... } filecheck { verificando arquivos... } other {on no} }"
+    },
+    "no_updates_found": "Nenhuma atualização encontrada para núcleos instalados"
+  },
+  "core_info": {
+    "author": "Autor",
+    "controls": {
+      "back": "Voltar à lista",
+      "install": "Instalar",
+      "required_files": "Arquivos Necessários",
+      "uninstall": "Desinstalar",
+      "update": "Atualizar"
+    },
+    "inputs": "Entradas",
+    "modal": {
+      "close": "Fechar",
+      "input_core": "Núcleo",
+      "no_settings_found": "Nenhuma configuração encontrada!",
+      "reset_all": "Reiniciar Tudo"
+    },
+    "requires_license": {
+      "all": "Aviso - este núcleo atualmente requer um arquivo de licença para funcionar.",
+      "jotego": "As betas do JOTEGO requerem um arquivo JTBETA do Patreon na seção de patrocinadores abaixo. \nO jtbeta.zip deve ser colocado na raiz do seu cartão SD, então será encontrado e copiado para o local certo durante o processo \"Arquivos Necessários\"."
+    },
+    "firmware_too_low": "Este núcleo precisa do firmware v{core_firmware}, a versão atualmente instalada é v{pocket_firmware}",
+    "not_in_inventory": "{coreName} não está no inventário de núcleos",
+    "platform": {
+      "edit": "Editar",
+      "wikipedia": "Wikipedia"
+    },
+    "replaced": "Este núcleo foi substituído por <1>{replacementCore}</1>",
+    "platforms": "Plataformas",
+    "release_date": "Data de Lançamento",
+    "releases": {
+      "release_history": "Histórico de Lançamentos",
+      "show_previous": "Mostrar lançamentos anteriores"
+    },
+    "required_files": "Arquivos Necessários",
+    "required_files_count": "{count} / {total} Arquivos",
+    "settings": "Configurações",
+    "sponsor": "Patrocinador",
+    "supports": "Suporta",
+    "supports_items": {
+      "cartridges": "Cartuchos",
+      "dock": "Dock",
+      "dock_dac": "Dock (Analógico)",
+      "save_states_and_sleep": "Estados de Gravação / Sono"
+    },
+    "url": "URL",
+    "version": "Versão",
+    "display_modes_title": "Modos de Exibição",
+    "display_mode_warning": "Este modo de exibição requer que o núcleo seja atualizado, tem certeza de que deseja ativá-lo?",
+    "info_txt_title": "Info.txt",
+    "display_modes": {
+      "crt_trinitron": "CRT Trinitron",
+      "grayscale_lcd": "LCD em Escala de Cinza",
+      "original_gb_dmg": "GB DMG Original",
+      "original_gbp": "GBP Original",
+      "original_gbp_light": "GBP Light Original",
+      "reflective_color_lcd": "LCD Colorido Reflexivo",
+      "original_gbc_lcd": "GBC LCD Original",
+      "original_gbc_lcd_plus": "GBC LCD+ Original",
+      "backlit_color_lcd": "LCD Colorido Retroiluminado",
+      "original_gba_lcd": "GBA LCD Original",
+      "original_gba_sp_101": "GBA SP 101 Original",
+      "original_gg": "GG Original",
+      "original_gg_plus": "GG+ Original",
+      "pinball_neon_matrix": "Matriz de Néon Pinball"
+    }
+  },
+  "core_info_required_files": {
+    "close": "Fechar",
+    "download_all": "Baixar Tudo",
+    "no_link_tip": "Por favor, consulte a seção Configurações para mais opções com arquivos necessários",
+    "skip_alternates_label": "Ignorar arquivos alternativos",
+    "title": "Arquivos Necessários",
+    "file_status": {
+      "needs_update_from_archive": "Atualizável",
+      "missing_but_on_archive": "Downloadável",
+      "not_found": "Não encontrado no arquivo",
+      "exists": "Baixado",
+      "not_checked": "Desconhecido",
+      "found_at_root": "Arquivo verificado. Encontrado na raiz",
+      "root_needs_update": "Incompatibilidade de arquivo. Por favor, verifique a raiz"
+    }
+  },
+  "cores": {
+    "controls": {
+      "category": "Categoria",
+      "sort": "Ordenar por",
+      "refresh": "Atualizar",
+      "search": "Pesquisar",
+      "updatable": "Atualizável",
+      "update_all": "Atualizar Tudo",
+      "filters_group": "Filtros",
+      "sort_options": {
+        "name": "Nome",
+        "last_update": "Última atualização"
+      }
+    },
+    "install_tip": "Você também pode instalar núcleos (ou qualquer outra coisa em um zip) arrastando o .zip para esta janela",
+    "installed": "Instalado ({count})",
+    "not_installed": "Disponível ({count})"
+  },
+  "error": {
+    "report": "Você pode reportar isso via GitHub inclua o texto abaixo e qualquer coisa que você acabou de fazer",
+    "retry": "Tentar Novamente",
+    "title": "Erro"
+  },
+  "fetch": {
+    "controls": {
+      "add_fetch_item": "Adicionar novo fetch",
+      "refresh": "Atualizar"
+    },
+    "fetch_button": "Buscar",
+    "file_count": "{count} / {total, plural, one {# Arquivo} other {# Arquivos}}",
+    "loading": "carregando...",
+    "new": {
+      "add_extension": "Adicionar",
+      "add_fetch": "Adicionar fetch",
+      "archive_name": "Nome do arquivo: <i>https://archive.org/details/[esta parte aqui]</i>",
+      "archive_tip": "Isso não funcionará para arquivos onde os arquivos estão zipados, e você deve definir quais extensões você quer evitar baixar os arquivos de metadados.",
+      "close": "Fechar",
+      "destination": "Pasta de Destino",
+      "extensions": "Limitar a Extensões de Arquivo:",
+      "origin": "Pasta de Origem",
+      "title": "Adicionar novo Fetch",
+      "validating_archive_name": "Verificando o arquivo \"{name}\"...",
+      "invalid_archive_name": "Nenhum arquivo encontrado em https://archive.org/details/{name}"
+    },
+    "remove_button": "Remover",
+    "remove_confirm": "Isso removerá a configuração do fetch, mas não os arquivos. Tem certeza?",
+    "types": {
+      "archive_org": "Internet Archive",
+      "filesystem": "Arquivos Locais"
+    }
+  },
+  "firmware": {
+    "current": "Firmware Atual: v{version}",
+    "downloading_firmware": "Baixando Firmware...",
+    "load_firmware": "Carregar no Cartão SD",
+    "loaded_firmware": "Firmware {version} está no cartão SD",
+    "loaded_firmware_info": "Insira e ligue o Pocket para instalar",
+    "no_firmware_loaded": "Nenhum arquivo de firmware no cartão SD à espera de ser instalado",
+    "options": {
+      "latest": "v{version} (mais recente)",
+      "older": "v{version} ({date, date, short})",
+      "previous_versions": "Versões Anteriores"
+    },
+    "release_notes": {
+      "from": "De ",
+      "title": "Notas de Lançamento v{version}:"
+    },
+    "remove_button": "Remover"
+  },
+  "games": {
+    "controls": {
+      "category": "Categoria",
+      "clean_files": "Limpar Arquivos",
+      "instance_json": "Instance JSON",
+      "refresh": "Atualizar",
+      "search": "Pesquisar"
+    },
+    "item": {
+      "game_count": "{count, plural, =0 {Nenhum Jogo} one {# Jogo} other {# Jogos}}"
+    }
+  },
+  "image_editor": {
+    "cancel": "Cancelar",
+    "import_image": "Importar Imagem",
+    "remove": "Remover",
+    "reset": "Reiniciar",
+    "rotate": "Rodar",
+    "save": "Guardar",
+    "scale": "Redimensionar"
+  },
+  "instance_json": {
+    "available_for": "Criação automática do arquivo instance.json disponível para:",
+    "close_button": "Fechar",
+    "skipped_file": "Arquivo {file_name} ignorado",
+    "title": "Construir arquivos instance.json",
+    "wrote_file": "Escreveu {file_name}"
+  },
+  "layout": {
+    "cores": "Núcleos",
+    "fetch": "Fetch",
+    "firmware": "Firmware",
+    "palettes": "Paletas",
+    "games": "Jogos",
+    "platforms": "Plataformas",
+    "pocket_sync": "Sincronização Pocket",
+    "save_states": "Estados de Gravação",
+    "saves": "Gravações",
+    "screenshots": "Capturas de Tela",
+    "settings": "Configurações"
+  },
+  "palettes": {
+    "buttons": {
+      "add_via_code": "Adicionar via código",
+      "new": "Nova Paleta",
+      "back": "Voltar à lista",
+      "palette_town": "Cidade das Paletas"
+    },
+    "town": {
+      "title": "Cidade das Paletas",
+      "repo_link": "Paletas de <1>github.com/{repo}</1>",
+      "close": "Fechar"
+    },
+    "item": {
+      "duplicate": "Duplicar",
+      "rename": "Renomear",
+      "copy_code": "Copiar código de compartilhamento",
+      "delete": "Eliminar"
+    },
+    "add_via_code": {
+      "title": "Adicionar via código de compartilhamento",
+      "cancel": "Cancelar",
+      "add": "Adicionar"
+    },
+    "full": {
+      "inputs": {
+        "background": "Fundo",
+        "obj0": "Obj0",
+        "obj1": "Obj1",
+        "window": "janela",
+        "off": "LCD desligado"
+      },
+      "save": "Guardar",
+      "reset": "Reiniciar",
+      "emu_credit": "Emulador GB adaptado de <1>roblouie/gameboy-emulator</1>"
+    }
+  },
+  "mister_sync": {
+    "controls": {
+      "back": "Sair",
+      "search": "Pesquisar Gravações",
+      "save_mapping": "Mapeamento de Gravação"
+    },
+    "login": {
+      "connect": "Conectar",
+      "host": "Host / Endereço IP:",
+      "password": "Senha:",
+      "username": "Nome de utilizador:"
+    },
+    "mister": "MiSTer",
+    "not_found": "Não encontrado",
+    "pocket": "Pocket",
+    "tip_1": "O FTP do MiSTer deve estar ativado",
+    "tip_2": "Certifique-se de que a gravação é compatível entre Pocket & MiSTer antes da transferência",
+    "tip_3": "O jogo deve ter exatamente o mesmo nome no Pocket e no MiSTer para que a gravação seja encontrada",
+    "unsupported": "{platform} não está mapeado",
+    "mapping": {
+      "close": "Fechar",
+      "clear": "Limpar",
+      "reset": "Restaurar padrão"
+    }
+  },
+  "news_feed": {
+    "last_updated": "Última atualização <1></1>",
+    "updates_from": "Atualizações do <1>Inventário de Núcleos OpenFPGA</1>"
+  },
+  "platform_info": {
+    "controls": {
+      "back": "Voltar à lista",
+      "data_packs": "Pacotes de Dados",
+      "image_packs": "Pacotes de Imagens"
+    },
+    "cores": "Núcleos",
+    "edit": "Editar"
+  },
+  "platforms": {
+    "cancel": "Cancelar",
+    "controls": {
+      "data_packs": "Pacotes de Dados",
+      "remove_coreless": "Remover Sem Núcleo",
+      "image_packs": "Pacotes de Imagens",
+      "search": "Pesquisar"
+    },
+    "data_packs": {
+      "apply_changes": "Aplicar {count, plural, =0 {0 Alterações} one {1 Alteração} other {# Alterações}}",
+      "close": "Fechar",
+      "current": "Atual"
+    },
+    "delete_unused": "Excluir {count, plural, one {# plataforma não utilizada} other {# plataformas não utilizadas}}?",
+    "edit": "Editar",
+    "image_packs": {
+      "apply_changes": "Aplicar {count, plural, =0 {0 Alterações} one {1 Alteração} other {# Alterações}}",
+      "close": "Fechar",
+      "current": "Atual"
+    },
+    "save": "Guardar"
+  },
+  "progress": {
+    "remaining_time": "Tempo Restante (aprox.): {remainingTime}"
+  },
+  "save_info": {
+    "confirm_restore": "Restaurar do backup?",
+    "controls": {
+      "back": "Voltar à lista",
+      "hide_unchanged": "Ocultar Inalterados",
+      "search": "Pesquisar"
+    },
+    "current": "Atual",
+    "date": "{date, date, short}",
+    "newer": "Mais recente",
+    "older": "Mais antigo",
+    "time": "{date, time, short}"
+  },
+  "save_states": {
+    "cartridge": "Cartucho",
+    "confirm_delete": "Tem certeza de que deseja eliminar {count, plural, =0 {nenhum estado de gravação} one {um estado de gravação} other {# estados de gravação}}?",
+    "controls": {
+      "clear_selection": "Limpar Seleção",
+      "delete_selection": "Eliminar Selecionados ({count})",
+      "search": "Pesquisar"
+    },
+    "count": "({count} / 128)",
+    "item": {
+      "date": "{date, date, long}",
+      "time": "{date, time, short}"
+    },
+    "photos": {
+      "title": "Exportação de Foto",
+      "palette": "Paleta",
+      "custom": "Personalizado",
+      "close": "Fechar",
+      "export_selected": "Exportar Selecionados",
+      "export_all": "Exportar Tudo",
+      "colours": {
+        "gb": "GB",
+        "gb_player": "GB Player",
+        "black_and_white": "Preto e Branco"
+      }
+    }
+  },
+  "saves": {
+    "backups": "Backups: {count}",
+    "confirm_delete": "Tem certeza de que deseja remover este local de backup?",
+    "controls": {
+      "add_backup_location": "Adicionar local de backup",
+      "mister_sync": "Sincronização MiSTer"
+    },
+    "latest_backup": "Último Backup: {date, date, long}, {date, time, short}",
+    "none": "Adicione um local de backup acima",
+    "not_found": "Não encontrado",
+    "oldest_backup": "Backup Mais Antigo: {date, date, long}, {date, time, short}",
+    "remove": "Remover Local",
+    "view_saves": "Ver Gravações"
+  },
+  "screenshot_info": {
+    "controls": {
+      "back": "Voltar à lista",
+      "save": "Guardar",
+      "share": "Compartilhar",
+      "upscaled": "Ampliado"
+    }
+  },
+  "screenshots": {
+    "controls": {
+      "delete_selected": "Eliminar Selecionados ({count})",
+      "export_selected": "Exportar Selecionados ({count})",
+      "search": "Pesquisar",
+      "select": "Selecionar"
+    },
+    "no_screenshots": "Uma vez que você tirar algumas capturas de tela, elas aparecerão aqui"
+  },
+  "settings": {
+    "3d_pocket": {
+      "title": "Cor do Pocket:",
+      "colours": {
+        "black": "Preto",
+        "white": "Branco",
+        "glow": "Brilha no Escuro",
+        "trans_clear": "Transparente",
+        "trans_smoke": "Fumo",
+        "trans_blue": "Azul",
+        "trans_green": "Verde",
+        "trans_orange": "Laranja",
+        "trans_purple": "Roxo",
+        "trans_red": "Vermelho",
+        "indigo": "Índigo",
+        "red": "Vermelho",
+        "green": "Verde",
+        "blue": "Azul",
+        "yellow": "Amarelo",
+        "pink": "Rosa",
+        "orange": "Laranja",
+        "silver": "Prateado"
+      },
+      "classic_label": "Clássico",
+      "transparent_label": "Transparente",
+      "body_label": "Corpo",
+      "buttons_label": "Botões",
+      "match_body": "Combinar com o Corpo"
+    },
+    "alternate_skip": {
+      "checkbox": "Ignorar Ativos Alternativos",
+      "ramble_1": "Esta configuração ignorará o processamento de arquivos json na pasta '_alternatives',\nou seja, você obterá apenas os títulos \"principais\" para os núcleos que organizam seus arquivos JSON desta forma.",
+      "ramble_2": "<b>Aviso:</b> desativar isso fará com que a instalação de Arquivos Necessários demore <b>muito</b> mais.",
+      "title": "Ignorar Ativos Alternativos"
+    },
+    "language": {
+      "checkbox": "Sempre usar Inglês (EUA)",
+      "title": "Idioma"
+    },
+    "archive": {
+      "save": "Guardar",
+      "title": "Arquivo ROM & BIOS (Arquivos Necessários)",
+      "warning": "Por favor, verifique as leis locais sobre o download de arquivos ROM & BIOS de arcade potencialmente protegidos por direitos autorais.\nSe você estiver confortável com isso, copie a seguinte url no campo de entrada e clique em \"Guardar\"."
+    },
+    "clear_file_cache": {
+      "button": "Limpar cache de arquivos",
+      "ramble": "Para ajudar com a transferência de arquivos grandes via USB & cartão SD, arquivos maiores são copiados e armazenados no sistema de arquivos do seu computador,\no que deve ser bom, mas se você estiver enfrentando problemas, tente limpar o cache de arquivos.",
+      "title": "Limpar cache de arquivos"
+    },
+    "disconnect": {
+      "button": "Desconectar",
+      "ramble": "Voltar à tela \"Conectar ao Pocket\" (Isso não ejeta o cartão SD / unidade USB)",
+      "title": "Desconectar"
+    },
+    "reconnect": {
+      "checkbox": "Reconectar quando aberto",
+      "ramble": "Tentar reconectar ao local mais recentemente aberto <1> {ppath} </1> ao abrir o aplicativo, pulando o botão \"Conectar ao Pocket\"",
+      "title": "Reconectar quando o aplicativo for aberto"
+    },
+    "turbo_downloads": {
+      "checkbox": "Ativar Downloads Rápidos",
+      "ramble": "Ativar esta configuração dividirá os arquivos do arquivo em pedaços menores. Esses pedaços são então baixados em paralelo, potencialmente resultando em uma aceleração de até 8 vezes. No entanto, este método consumirá mais largura de banda e pode ser menos confiável. Se você ativá-lo, por favor, considere <1>apoiar o Internet Archive</1>.",
+      "title": "Downloads Rápidos"
+    },
+    "logs": {
+      "title": "Registros",
+      "button": "Abrir Pasta de Registros"
+    },
+    "thanks": "Agradecimentos a:"
+  },
+  "time_ago": {
+    "less_than_1_min_ago": "há menos de um minuto"
+  },
+  "uninstall_core": {
+    "confirm_text": "Isso removerá o núcleo, mas não qualquer jogo, gravações, dados da biblioteca ou informações da plataforma. Tem certeza?",
+    "confirm_title": "Desinstalar Núcleo"
+  },
+  "zip_install": {
+    "cancel_button": "Cancelar",
+    "confirm_button": "Confirmar",
+    "remove_duplicate": "Remover arquivos duplicados existentes",
+    "scanning": "Analisando arquivos...",
+    "moved_files_info": "Trata casos onde arquivos foram movidos, por exemplo, arquivos JSON agora estão na pasta '_alternatives'",
+    "replace": {
+      "ok": "Permitir",
+      "cancel": "Saltar",
+      "text": "{list}\n\nAtivos, Gravações etc serão transferidos e o núcleo antigo será removido.",
+      "title": "Substituir Núcleos?"
+    }
+  },
+  "version": {
+    "update_alt": "Atualização {version} disponível",
+    "replaced_alt": "Núcleo de substituição {core} disponível",
+    "replaced": "Substituído"
+  }
+}


### PR DESCRIPTION
This pull request adds European Portuguese translations to the user interface. Tried my best to ensure that nouns and verbs can also be understood by users looking for Brazilian Portuguese.

**Changes:**
- Added `pt/index.json` with full translations of the application's UI text.
- Translations were made in European Portuguese (Portugal), which will also suffice for Brazilian Portuguese, hence why `pt` and not `pt-pt` or `pt-br` was created and added to the list of languages.

