### PR TITLE
Adds an auto-repair feature

### DIFF
--- a/src/components/errorBoundary/index.css
+++ b/src/components/errorBoundary/index.css
@@ -16,3 +16,47 @@
   flex-grow: 1;
   overflow: auto;
 }
+
+.error-boundary__buttons{
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.error-boundary__repair-button{
+  font-size: 1.1rem;
+  background-color: var(--green-colour);
+  text-shadow: 0 0 2px rgb(0 0 0 / 80%);
+  border: 2px solid white;
+  animation: border-pulse 2s linear infinite;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 16px;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  max-width: 100%;
+}
+
+@keyframes border-pulse {
+  0%, 100% {
+    border-color: white;
+  }
+
+  50% {
+    border-color: transparent;
+  }
+}
+
+.error-boundary__repair-button-title{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.2em;
+  font-size: 1.25rem;
+  font-weight: bold;
+}
+
+.error-boundary__repair-button-title--in-progress{
+  grid-column: 1 / span 3;
+}

--- a/src/components/errorBoundary/index.tsx
+++ b/src/components/errorBoundary/index.tsx
@@ -6,6 +6,8 @@ import "./index.css"
 import { ViewDebug } from "./viewDebug"
 import { Trans } from "react-i18next"
 import { openLogDir } from "../../utils/openLogDir"
+import { RepairButton } from "./repair"
+import { NulledErrorBoundary } from "./nulledBoundary"
 
 type ErrorBoundaryProps = {
   children?: ReactNode
@@ -66,16 +68,23 @@ export class ErrorBoundary extends Component<
           </div>
           <div className="error-boundary__stack">{this.state.error?.stack}</div>
 
-          <button
-            onClick={() => openLogDir()}
-            style={{ marginBlockEnd: "20px" }}
-          >
-            <Trans i18nKey="settings:logs.button"></Trans>
-          </button>
+          <div className="error-boundary__buttons">
+            {this.state.error && (
+              <NulledErrorBoundary>
+                <RepairButton
+                  error={this.state.error}
+                  onFinishRepair={() => this.clearError()}
+                />
+              </NulledErrorBoundary>
+            )}
+            <button onClick={() => openLogDir()}>
+              <Trans i18nKey="settings:logs.button"></Trans>
+            </button>
 
-          <button style={{ width: "100%" }} onClick={() => this.clearError()}>
-            <Trans i18nKey="error:retry"></Trans>
-          </button>
+            <button onClick={() => this.clearError()}>
+              <Trans i18nKey="error:retry"></Trans>
+            </button>
+          </div>
         </div>
       )
     }

--- a/src/components/errorBoundary/index.tsx
+++ b/src/components/errorBoundary/index.tsx
@@ -1,4 +1,4 @@
-import { Component, ErrorInfo, ReactNode } from "react"
+import { Component, ErrorInfo, ReactNode, Suspense } from "react"
 import { Link } from "../link"
 import { Tip } from "../tip"
 
@@ -71,10 +71,12 @@ export class ErrorBoundary extends Component<
           <div className="error-boundary__buttons">
             {this.state.error && (
               <NulledErrorBoundary>
-                <RepairButton
-                  error={this.state.error}
-                  onFinishRepair={() => this.clearError()}
-                />
+                <Suspense>
+                  <RepairButton
+                    error={this.state.error}
+                    onFinishRepair={() => this.clearError()}
+                  />
+                </Suspense>
               </NulledErrorBoundary>
             )}
             <button onClick={() => openLogDir()}>

--- a/src/components/errorBoundary/nulledBoundary.tsx
+++ b/src/components/errorBoundary/nulledBoundary.tsx
@@ -1,0 +1,38 @@
+import { Component, ErrorInfo, ReactNode } from "react"
+
+type NulledErrorBoundaryProps = {
+  children?: ReactNode
+}
+
+type NulledErrorBoundaryState = {
+  hasError: boolean
+  error: Error | null
+}
+
+export class NulledErrorBoundary extends Component<
+  NulledErrorBoundaryProps,
+  NulledErrorBoundaryState
+> {
+  public state: NulledErrorBoundaryState = {
+    hasError: false,
+    error: null,
+  }
+
+  public static getDerivedStateFromError(err: Error): NulledErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error: err }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Uncaught error:", error, errorInfo)
+  }
+
+  clearError() {
+    this.setState({ hasError: false, error: null })
+  }
+
+  public render() {
+    if (this.state.hasError) return null
+    return this.props.children
+  }
+}

--- a/src/components/errorBoundary/repair.tsx
+++ b/src/components/errorBoundary/repair.tsx
@@ -59,19 +59,22 @@ const RepairMissingPlatform = ({
 }: {
   platformId: PlatformId
   onFinishRepair: () => void
-}): ReactElement | null => {
+}): ReactElement => {
   const coresForPlatform = useRecoilValue(
     CoresForPlatformSelectorFamily(platformId)
   )
 
-  if (coresForPlatform.length === 0) return null
-
   return (
-    <RepairMissingPlatformInner
-      coreName={coresForPlatform[0]}
-      platformId={platformId}
-      onFinishRepair={onFinishRepair}
-    />
+    <>
+      {coresForPlatform.map((coreName) => (
+        <RepairMissingPlatformInner
+          key={coreName}
+          coreName={coreName}
+          platformId={platformId}
+          onFinishRepair={onFinishRepair}
+        />
+      ))}
+    </>
   )
 }
 

--- a/src/components/errorBoundary/repair.tsx
+++ b/src/components/errorBoundary/repair.tsx
@@ -1,0 +1,159 @@
+import { ReactElement, useCallback, useMemo, useState } from "react"
+import { PlatformId } from "../../types"
+import { useInstallCore } from "../../hooks/useInstallCore"
+import { useRecoilValue } from "recoil"
+import { CoresForPlatformSelectorFamily } from "../../recoil/platforms/selectors"
+import { DownloadURLSelectorFamily } from "../../recoil/inventory/selectors"
+import { usePreventGlobalZipInstallModal } from "../../hooks/usePreventGlobalZipInstall"
+import { emit, once } from "@tauri-apps/api/event"
+import { RepairIcon } from "./repairIcon"
+import { Trans } from "react-i18next"
+
+type RepairButtonProps = {
+  error: Error
+  onFinishRepair: () => void
+}
+
+type RepairableCause = {
+  type: "missing_platform"
+  platform_id: PlatformId
+  repairable: true
+}
+
+export const RepairButton = ({
+  error,
+  onFinishRepair,
+}: RepairButtonProps): ReactElement | null => {
+  const { installCore } = useInstallCore()
+
+  const repairableCause: RepairableCause | null = useMemo(() => {
+    if (
+      error.cause &&
+      //@ts-ignore
+      error.cause.repairable
+    ) {
+      return error.cause as RepairableCause
+    }
+    return null
+  }, [])
+
+  if (!repairableCause) return null
+
+  switch (repairableCause.type) {
+    case "missing_platform":
+      return (
+        <RepairMissingPlatform
+          platformId={repairableCause.platform_id}
+          onFinishRepair={onFinishRepair}
+        />
+      )
+
+    default:
+      return null
+  }
+}
+
+const RepairMissingPlatform = ({
+  platformId,
+  onFinishRepair,
+}: {
+  platformId: PlatformId
+  onFinishRepair: () => void
+}): ReactElement | null => {
+  const coresForPlatform = useRecoilValue(
+    CoresForPlatformSelectorFamily(platformId)
+  )
+
+  if (coresForPlatform.length === 0) return null
+
+  return (
+    <RepairMissingPlatformInner
+      coreName={coresForPlatform[0]}
+      platformId={platformId}
+      onFinishRepair={onFinishRepair}
+    />
+  )
+}
+
+type RepairMissingPlatformInner = {
+  coreName: string
+  platformId: PlatformId
+  onFinishRepair: () => void
+}
+
+// Would be easy to convert this to a generic "missing file" one if more missing file bugs come in
+const RepairMissingPlatformInner = ({
+  coreName,
+  platformId,
+  onFinishRepair,
+}: RepairMissingPlatformInner): ReactElement | null => {
+  const [isRepairing, setIsRepairing] = useState(false)
+  usePreventGlobalZipInstallModal()
+
+  const downloadUrl = useRecoilValue(DownloadURLSelectorFamily(coreName))
+
+  const callback = useCallback(async () => {
+    setIsRepairing(true)
+    await emit("install-core", {
+      core_name: coreName,
+      zip_url: downloadUrl,
+    })
+
+    await (() => {
+      let outerResolve: null | ((value: null) => void) = null
+      const promise = new Promise((resolve) => (outerResolve = resolve))
+      once("install-zip-event", () => outerResolve?.(null))
+      return promise
+    })()
+
+    await emit("install-confirmation", {
+      type: "InstallConfirmation",
+      paths: [`platforms/${platformId}.json`],
+      handle_moved_files: false,
+      allow: true,
+    })
+
+    await (() => {
+      let outerResolve: null | ((value: null) => void) = null
+      const promise = new Promise((resolve) => (outerResolve = resolve))
+      once("install-zip-finished", () => outerResolve?.(null))
+      return promise
+    })()
+
+    await new Promise((resolve) => window.setTimeout(resolve, 2e3))
+
+    onFinishRepair()
+  }, [coreName, platformId, onFinishRepair, setIsRepairing])
+
+  if (!downloadUrl) return null
+
+  if (isRepairing) {
+    return (
+      <button className="error-boundary__repair-button">
+        <div className="error-boundary__repair-button-title error-boundary__repair-button-title--in-progress">
+          <RepairIcon />
+          <Trans i18nKey="error:repair:in_progress"></Trans>
+        </div>
+      </button>
+    )
+  }
+
+  return (
+    <button onClick={callback} className="error-boundary__repair-button">
+      <div className="error-boundary__repair-button-title">
+        <RepairIcon />
+        <Trans i18nKey="error:repair:title"></Trans>
+      </div>
+      <div>
+        <Trans
+          i18nKey="error:repair:fixes:redownload_file"
+          values={{ path: `Platforms/${platformId}.json`, coreName }}
+          components={{
+            pre: <pre style={{ display: "inline" }} />,
+            bold: <strong />,
+          }}
+        ></Trans>
+      </div>
+    </button>
+  )
+}

--- a/src/components/errorBoundary/repairIcon.tsx
+++ b/src/components/errorBoundary/repairIcon.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from "react"
+
+export const RepairIcon = (): ReactElement => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="1em"
+    viewBox="0 -960 960 960"
+    width="1em"
+    fill="currentColor"
+  >
+    <path d="M204-318q-22-38-33-78t-11-82q0-134 93-228t227-94h7l-64-64 56-56 160 160-160 160-56-56 64-64h-7q-100 0-170 70.5T240-478q0 26 6 51t18 49l-60 60ZM481-40 321-200l160-160 56 56-64 64h7q100 0 170-70.5T720-482q0-26-6-51t-18-49l60-60q22 38 33 78t11 82q0 134-93 228t-227 94h-7l64 64-56 56Z" />
+  </svg>
+)

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -153,7 +153,14 @@
   "error": {
     "report": "You can report this via GitHub include the text below & whatever you just did",
     "retry": "Retry",
-    "title": "Error"
+    "title": "Error",
+    "repair": {
+      "title": "Repair",
+      "in_progress": "Repairing...",
+      "fixes": {
+        "redownload_file": "Redownload <pre>{path}</pre> from <bold>{coreName}</bold>"
+      }
+    }
   },
   "fetch": {
     "controls": {

--- a/src/recoil/platforms/selectors.ts
+++ b/src/recoil/platforms/selectors.ts
@@ -81,7 +81,14 @@ export const PlatformInfoSelectorFamily = selectorFamily<
       const path = `Platforms/${platformId}.json`
       get(FileWatchAtomFamily(path))
       const exists = await invokeFileExists(path)
-      if (!exists) throw new Error(`Attempt to read platform_id ${platformId}`)
+      if (!exists)
+        throw new Error(`Missing File: ${path}`, {
+          cause: {
+            type: "missing_platform",
+            platform_id: platformId,
+            repairable: true,
+          },
+        })
       return readJSONFile<PlatformInfoJSON>(path)
     },
 })


### PR DESCRIPTION
- Thrown errors can now put structured data in their `cause` which'll get picked up by the error boundary & given to the repair button component
- The repair button looks at the cause & determines if it can present an auto-repair to the user
- Can show multiple repair options if multiple cores implement 1 platform

- Allows for user self-repair for this issue type:
  - https://github.com/neil-morrison44/pocket-sync/issues/325
  - https://github.com/neil-morrison44/pocket-sync/issues/317
  - https://github.com/neil-morrison44/pocket-sync/issues/294

- Can, potentially, catch other errors in the future (so long as we know the core name & what file it is)
