### PR TITLE
Handles photo export for post-2.3 save states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pocket-sync",
-  "version": "4.0.2",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pocket-sync",
-      "version": "4.0.2",
+      "version": "5.1.0",
       "dependencies": {
         "@neil-morrison44/gameboy-emulator": "^1.3.0",
         "@prantlf/jsonlint": "11.7.0",
@@ -31,7 +31,7 @@
         "html-react-parser": "^5.1.18",
         "i18next": "^23.15.2",
         "i18next-icu": "^2.3.0",
-        "mdast-util-gfm-autolink-literal": "2.0.1",
+        "mdast-util-gfm-autolink-literal": "2.0.0",
         "postprocessing": "^6.36.3",
         "r3f-perf": "^7.2.2",
         "react": "^18.3.1",
@@ -6634,9 +6634,9 @@
       }
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
-      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.0.tgz",
+      "integrity": "sha512-FyzMsduZZHSc3i0Px3PQcBT4WJY/X/RCtEJKuybiC6sjPqLv7h1yqAkmILZtuxMSsUyaLUWNp71+vQH2zqp5cg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "html-react-parser": "^5.1.18",
     "i18next": "^23.15.2",
     "i18next-icu": "^2.3.0",
-    "mdast-util-gfm-autolink-literal": "2.0.1",
+    "mdast-util-gfm-autolink-literal": "2.0.0",
     "postprocessing": "^6.36.3",
     "r3f-perf": "^7.2.2",
     "react": "^18.3.1",

--- a/src/components/saveStates/index.tsx
+++ b/src/components/saveStates/index.tsx
@@ -79,10 +79,12 @@ export const SaveStates = () => {
       </Controls>
 
       {isExportingPhotos && (
-        <PhotoExportModal
-          path={isExportingPhotos}
-          onClose={() => setIsExportingPhotos(null)}
-        />
+        <Suspense>
+          <PhotoExportModal
+            path={isExportingPhotos}
+            onClose={() => setIsExportingPhotos(null)}
+          />
+        </Suspense>
       )}
 
       <div className="save-states__list">

--- a/src/recoil/saveStates/selectors.ts
+++ b/src/recoil/saveStates/selectors.ts
@@ -85,7 +85,6 @@ export const PhotoExportImageSelectorFamily = selectorFamily<
   get:
     ({ path, index }) =>
     async ({ get }) => {
-      const saveMetadata = get(SaveStateMetadataSelectorFamily(path))
       const saveData = get(ReadSavForStaSelectorFamily(path))
       const canvas = document.createElement("canvas")
       canvas.width = 128


### PR DESCRIPTION
- Fixes https://github.com/neil-morrison44/pocket-sync/issues/334
- Also keeps older save states working by detecting the type of save using the "Magic" word
- Also re-pins `mdast-util-gfm-autolink-literal` to 2.0.0 re-fixing https://github.com/neil-morrison44/pocket-sync/issues/330