### PR TITLE
Add support for using a GitHub PAT token

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "5.2.0",
+  "version": "5.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-sync"
-version = "5.2.0"
+version = "5.3.0"
 dependencies = [
  "anyhow",
  "async-walkdir",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-sync"
-version = "5.2.0"
+version = "5.3.0"
 description = "A GUI tool for doing stuff with the Analogue Pocket"
 authors = ["neil-morrison44"]
 license = "AGPL-3.0"

--- a/src/components/errorBoundary/repair.tsx
+++ b/src/components/errorBoundary/repair.tsx
@@ -8,6 +8,7 @@ import { usePreventGlobalZipInstallModal } from "../../hooks/usePreventGlobalZip
 import { emit, once } from "@tauri-apps/api/event"
 import { RepairIcon } from "./repairIcon"
 import { Trans } from "react-i18next"
+import { githubTokenAtom } from "../../recoil/settings/atoms"
 
 const CORE_FILE_REGEX = /Cores[\/\\]([^\/\\]+)[\/\\]/
 const PLATFORM_FILE_REGEX = /Platforms[\/\\]([^\/\\]+)\.json/
@@ -168,6 +169,7 @@ const RepairRedownloadFiles = ({
   onFinishRepair,
 }: RepairRedownloadFilesProps): ReactElement | null => {
   const [isRepairing, setIsRepairing] = useState(false)
+  const githubToken = useRecoilValue(githubTokenAtom)
   usePreventGlobalZipInstallModal()
 
   const callback = useCallback(async () => {
@@ -175,6 +177,7 @@ const RepairRedownloadFiles = ({
     await emit("install-core", {
       core_name: coreName,
       zip_url: downloadUrl,
+      github_token: githubToken.value,
     })
 
     await (() => {

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -14,6 +14,7 @@ import { Thanks } from "./thanks"
 import { PocketColour } from "../../types"
 import {
   alwaysUseEnglishAtom,
+  githubTokenAtom,
   keepPlatformDataAtom,
   turboDownloadsAtom,
 } from "../../recoil/settings/atoms"
@@ -48,6 +49,7 @@ export const Settings = () => {
   )
 
   const patreonUrls = useRecoilValue(patreonKeyListSelector)
+  const [githubToken, setGithubToken] = useRecoilState(githubTokenAtom)
 
   return (
     <div className="settings">
@@ -256,6 +258,22 @@ export const Settings = () => {
           <label className="settings__checkbox">
             <button onClick={() => openLogDir()}>{t("logs.button")}</button>
           </label>
+        </div>
+
+        <div className="settings__row">
+          <h3 className="settings__row-title">{t("github_token.title")}</h3>
+          <div className="settings__ramble">{t("github_token.ramble")}</div>
+          <div className="settings__text-input-and-save">
+            <input
+              type="text"
+              className="settings__text-input"
+              value={githubToken.value || ""}
+              onChange={({ target }) => setGithubToken({ value: target.value })}
+            />
+            <button onClick={() => setGithubToken({ value: null })}>
+              {t("github_token.remove")}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/src/hooks/useInstallCore.ts
+++ b/src/hooks/useInstallCore.ts
@@ -1,13 +1,21 @@
 import { useCallback } from "react"
 import { emit } from "@tauri-apps/api/event"
+import { useRecoilValue } from "recoil"
+import { githubTokenAtom } from "../recoil/settings/atoms"
 
 export const useInstallCore = () => {
-  const installCore = useCallback(async (coreName: string, zipUrl: string) => {
-    emit("install-core", {
-      core_name: coreName,
-      zip_url: zipUrl,
-    })
-  }, [])
+  const githubToken = useRecoilValue(githubTokenAtom)
+
+  const installCore = useCallback(
+    async (coreName: string, zipUrl: string) => {
+      emit("install-core", {
+        core_name: coreName,
+        zip_url: zipUrl,
+        github_token: githubToken.value,
+      })
+    },
+    [githubToken]
+  )
 
   return { installCore }
 }

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -475,6 +475,11 @@
       "title": "ROM & BIOS archive (Required Files)",
       "warning": "Please check with your local laws around the downloading of potentially copyrighted (arcade) ROM & BIOS files.\nIf you are comfortable with this, copy the following url into the input and hit \"save\"."
     },
+    "github_token": {
+      "title": "Github Token",
+      "remove": "Remove",
+      "ramble": "If you're having issues with the GitHub rate limit, then add a PAT token below.\nThe PAT token shouldn't have any scopes set, and is stored on your computer rather than on the Pocket's SD card."
+    },
     "patreon_keys": {
       "title": "Patreon Keys",
       "update": "Get Keys",

--- a/src/recoil/github/selectors.ts
+++ b/src/recoil/github/selectors.ts
@@ -1,6 +1,8 @@
 import { GithubRelease } from "../../types"
 import { selectorFamily } from "recoil"
 import { coreInventoryAtom } from "../inventory/atoms"
+import { githubTokenAtom } from "../settings/atoms"
+import { githubHeadersSelector } from "../settings/selectors"
 
 export const GithubReleasesSelectorFamily = selectorFamily<
   GithubRelease[],
@@ -11,9 +13,11 @@ export const GithubReleasesSelectorFamily = selectorFamily<
     ({ owner, repo, latest }) =>
     async ({ get }) => {
       if (!latest) get(coreInventoryAtom)
+      const headers = get(githubHeadersSelector)
 
       const response = await fetch(
-        `https://api.github.com/repos/${owner}/${repo}/releases`
+        `https://api.github.com/repos/${owner}/${repo}/releases`,
+        { headers }
       )
 
       const remainingRateLimit = parseInt(

--- a/src/recoil/palettes/selectors.tsx
+++ b/src/recoil/palettes/selectors.tsx
@@ -9,6 +9,7 @@ import { fetch as TauriFetch } from "@tauri-apps/plugin-http"
 import { paletteRepoAtom } from "./atoms"
 import * as zip from "@zip.js/zip.js"
 import { error } from "@tauri-apps/plugin-log"
+import { githubHeadersSelector } from "../settings/selectors"
 
 export const palettesListSelector = selector<string[]>({
   key: "palettesListSelector",
@@ -92,9 +93,14 @@ export const palleteZipURLSelector = selector<string | null>({
   key: "palleteZipURLSelector",
   get: async ({ get }) => {
     const repo = get(paletteRepoAtom)
+    const headers = get(githubHeadersSelector)
+
     const response = await TauriFetch(
       `https://api.github.com/repos/${repo}/releases/latest`,
-      { method: "GET", headers: { "User-Agent": `Pocket Sync` } }
+      {
+        method: "GET",
+        headers,
+      }
     )
 
     const data = (await response.json()) as GithubRelease

--- a/src/recoil/settings/atoms.ts
+++ b/src/recoil/settings/atoms.ts
@@ -27,3 +27,11 @@ export const keepPlatformDataAtom = atom<{ enabled: boolean }>({
   }),
   effects: [syncToAppLocalDataEffect("keep-platform-data")],
 })
+
+export const githubTokenAtom = atom<{ value: string | null }>({
+  key: "githubTokenAtom",
+  default: syncToAppLocalDataEffectDefault("github-token-atom", {
+    value: null,
+  }),
+  effects: [syncToAppLocalDataEffect("github-token-atom")],
+})

--- a/src/recoil/settings/selectors.ts
+++ b/src/recoil/settings/selectors.ts
@@ -1,5 +1,6 @@
 import { selector } from "recoil"
 import { PatreonKeyInfo } from "../../types"
+import { githubTokenAtom } from "./atoms"
 
 export const patreonKeyListSelector = selector<PatreonKeyInfo[]>({
   key: "patreonKeyListSelector",
@@ -9,5 +10,14 @@ export const patreonKeyListSelector = selector<PatreonKeyInfo[]>({
     )
 
     return response.json()
+  },
+})
+
+export const githubHeadersSelector = selector<Record<string, string>>({
+  key: "githubHeadersSelector",
+  get: ({ get }) => {
+    const githubToken = get(githubTokenAtom)
+    if (!githubToken.value) return {} as Record<string, string>
+    return { Authorization: `Bearer ${githubToken.value}` }
   },
 })


### PR DESCRIPTION
- Closes #343
- Think I've got everywhere that reaches out to github.com (github.io doesn't need it)
- Chose to store it on the computer rather than in the JSON file on the SD card for if the Pocket is lost / stolen / sold
- though the PAT doesn't need anything other than public access