### PR TITLE
Adds a way to hide uninstalled cores & fixes annoying refresh jump

### DIFF
--- a/src/components/cores/item.tsx
+++ b/src/components/cores/item.tsx
@@ -18,6 +18,7 @@ import { useInventoryItem } from "../../hooks/useInventoryItem"
 import { PlatformInventoryImageSelectorFamily } from "../../recoil/inventory/selectors"
 import { PlatformImage } from "./platformImage"
 import { AnalogizerIcon } from "./icons/AnalogizerIcon"
+import { PocketSyncConfigSelector } from "../../recoil/config/selectors"
 
 type CoreItemProps = {
   coreName: string
@@ -99,9 +100,12 @@ export const NotInstalledCoreItem = ({
     PlatformInventoryImageSelectorFamily(platform_id)
   )
 
+  const config = useRecoilValue(PocketSyncConfigSelector)
   const authorImageUrl = `https://openfpga-cores-inventory.github.io/analogue-pocket/assets/images/authors/${identifier}.png`
-
   const [author] = identifier.split(".")
+
+  if (config.hidden_cores && config.hidden_cores.includes(identifier))
+    return null
 
   return (
     <SearchContextSelfHidingConsumer

--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -9,6 +9,7 @@ import { ZipInstall } from "../zipInstall"
 import "./index.css"
 import { useTranslation } from "react-i18next"
 import { enableGlobalZipInstallAtom } from "../../recoil/atoms"
+import { useRefHeight } from "../../hooks/useRefHeight"
 
 const Saves = React.lazy(() =>
   import("../saves").then((i) => ({ default: i.Saves }))
@@ -71,6 +72,7 @@ export const Layout = () => {
   }, [])
 
   const { view } = viewAndSubview
+  const [contentRef, heightRef] = useRefHeight()
 
   return (
     <div className="layout" ref={layoutRef}>
@@ -93,18 +95,20 @@ export const Layout = () => {
       </div>
       <div className="layout__content">
         <ErrorBoundary>
-          <Suspense fallback={<Loader fullHeight />}>
-            {view === "Screenshots" && <Screenshots />}
-            {view === "Cores" && <Cores />}
-            {view === "Pocket Sync" && <About />}
-            {view === "Settings" && <Settings />}
-            {view === "Games" && <Games />}
-            {view === "Saves" && <Saves />}
-            {view === "Save States" && <SaveStates />}
-            {view === "Firmware" && <Firmware />}
-            {view === "Platforms" && <Platforms />}
-            {view === "Palettes" && <Palettes />}
-            {view === "Fetch" && <Fetch />}
+          <Suspense fallback={<Loader heightRef={heightRef} />}>
+            <div ref={contentRef}>
+              {view === "Screenshots" && <Screenshots />}
+              {view === "Cores" && <Cores />}
+              {view === "Pocket Sync" && <About />}
+              {view === "Settings" && <Settings />}
+              {view === "Games" && <Games />}
+              {view === "Saves" && <Saves />}
+              {view === "Save States" && <SaveStates />}
+              {view === "Firmware" && <Firmware />}
+              {view === "Platforms" && <Platforms />}
+              {view === "Palettes" && <Palettes />}
+              {view === "Fetch" && <Fetch />}
+            </div>
           </Suspense>
         </ErrorBoundary>
       </div>

--- a/src/components/loader/index.tsx
+++ b/src/components/loader/index.tsx
@@ -1,3 +1,4 @@
+import { MutableRefObject } from "react"
 import "./index.css"
 
 type LoaderProps = {
@@ -5,6 +6,7 @@ type LoaderProps = {
   fullHeight?: boolean
   title?: string
   height?: number
+  heightRef?: MutableRefObject<number>
 }
 
 export const Loader = ({
@@ -12,10 +14,18 @@ export const Loader = ({
   fullHeight,
   height,
   title = "",
-}: LoaderProps) => (
-  <div
-    className={`loader ${className || ""} ${fullHeight ? "loader--full" : ""}`}
-    title={title}
-    style={{ height: height ? `${height}px` : undefined }}
-  ></div>
-)
+  heightRef,
+}: LoaderProps) => {
+  const heightValue = heightRef ? heightRef.current : height
+  const heightPx = heightValue ? `${heightValue}px` : undefined
+
+  return (
+    <div
+      className={`loader ${className || ""} ${
+        fullHeight ? "loader--full" : ""
+      }`}
+      title={title}
+      style={{ height: heightPx }}
+    ></div>
+  )
+}

--- a/src/components/settings/index.css
+++ b/src/components/settings/index.css
@@ -160,3 +160,33 @@
     --percent: 360deg;
   }
 }
+
+.settings__items-input-list{
+  background-color: var(--light-colour);
+  padding: 10px;
+  border-radius: 5px;
+  list-style: none;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-height: 20px;
+}
+
+.settings__items-input-item{
+  background-color: var(--info-colour);
+  padding: 5px 10px;
+  border-radius: inherit;
+  display: flex;
+  cursor: pointer;
+
+  &:hover{
+    transform: scale(1.05);
+  }
+
+  &::after{
+    content: "x";
+    font-family: monospace;
+    font-size: 1.1rem;
+    margin-inline-start: 5px;
+  }
+}

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -23,6 +23,8 @@ import { emit } from "@tauri-apps/api/event"
 import { openLogDir } from "../../utils/openLogDir"
 import { PatreonKeys } from "./patreonKeys"
 import { patreonKeyListSelector } from "../../recoil/settings/selectors"
+import { HiddenCores } from "./items/hiddenCores"
+import { GithubToken } from "./items/githubToken"
 
 export const Settings = () => {
   const config = useRecoilValue(PocketSyncConfigSelector)
@@ -49,7 +51,6 @@ export const Settings = () => {
   )
 
   const patreonUrls = useRecoilValue(patreonKeyListSelector)
-  const [githubToken, setGithubToken] = useRecoilState(githubTokenAtom)
 
   return (
     <div className="settings">
@@ -260,21 +261,8 @@ export const Settings = () => {
           </label>
         </div>
 
-        <div className="settings__row">
-          <h3 className="settings__row-title">{t("github_token.title")}</h3>
-          <div className="settings__ramble">{t("github_token.ramble")}</div>
-          <div className="settings__text-input-and-save">
-            <input
-              type="text"
-              className="settings__text-input"
-              value={githubToken.value || ""}
-              onChange={({ target }) => setGithubToken({ value: target.value })}
-            />
-            <button onClick={() => setGithubToken({ value: null })}>
-              {t("github_token.remove")}
-            </button>
-          </div>
-        </div>
+        <HiddenCores />
+        <GithubToken />
       </div>
 
       <Thanks />

--- a/src/components/settings/items/githubToken.tsx
+++ b/src/components/settings/items/githubToken.tsx
@@ -1,0 +1,26 @@
+import { useRecoilState } from "recoil"
+import { githubTokenAtom } from "../../../recoil/settings/atoms"
+import { useTranslation } from "react-i18next"
+
+export const GithubToken = () => {
+  const { t } = useTranslation("settings")
+  const [githubToken, setGithubToken] = useRecoilState(githubTokenAtom)
+
+  return (
+    <div className="settings__row">
+      <h3 className="settings__row-title">{t("github_token.title")}</h3>
+      <div className="settings__ramble">{t("github_token.ramble")}</div>
+      <div className="settings__text-input-and-save">
+        <input
+          type="text"
+          className="settings__text-input"
+          value={githubToken.value || ""}
+          onChange={({ target }) => setGithubToken({ value: target.value })}
+        />
+        <button onClick={() => setGithubToken({ value: null })}>
+          {t("github_token.remove")}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/settings/items/hiddenCores.tsx
+++ b/src/components/settings/items/hiddenCores.tsx
@@ -1,0 +1,41 @@
+import { useRecoilValue } from "recoil"
+import { PocketSyncConfigSelector } from "../../../recoil/config/selectors"
+import { useUpdateConfig } from "../hooks/useUpdateConfig"
+import { useTranslation } from "react-i18next"
+
+export const HiddenCores = () => {
+  const updateConfig = useUpdateConfig()
+  const { t } = useTranslation("settings")
+  const config = useRecoilValue(PocketSyncConfigSelector)
+  const hiddenCores = config.hidden_cores ?? []
+
+  const hasHiddenCores = hiddenCores.length !== 0
+
+  return (
+    <div className="settings__row">
+      <h3 className="settings__row-title">{t("hidden_cores.title")}</h3>
+      <div className="settings__ramble">{t("hidden_cores.ramble")}</div>
+      <ul className="settings__items-input-list">
+        {hiddenCores.map((coreName) => (
+          <li
+            key={coreName}
+            className="settings__items-input-item"
+            onClick={() =>
+              updateConfig(
+                "hidden_cores",
+                hiddenCores.filter((c) => c !== coreName)
+              )
+            }
+          >
+            {coreName}
+          </li>
+        ))}
+      </ul>
+      {hasHiddenCores && (
+        <button onClick={() => updateConfig("hidden_cores", [])}>
+          {t("hidden_cores.button")}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useRefHeight.ts
+++ b/src/hooks/useRefHeight.ts
@@ -1,0 +1,20 @@
+import { useCallback, useLayoutEffect, useRef } from "react"
+
+export const useRefHeight = () => {
+  const heightRef = useRef<number>(window.innerHeight)
+  const contentRef = useCallback((div: HTMLDivElement | null) => {
+    if (div) {
+      heightRef.current = div.scrollHeight
+      const resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          if (entry.contentBoxSize) {
+            const contentBoxSize = entry.contentBoxSize[0]
+            heightRef.current = div.scrollHeight
+          }
+        }
+      })
+      resizeObserver.observe(div)
+    }
+  }, [])
+  return [contentRef, heightRef] as const
+}

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -39,7 +39,8 @@
       "install": "Install",
       "required_files": "Required Files",
       "uninstall": "Uninstall",
-      "update": "Update"
+      "update": "Update",
+      "hide_core": "Hide Core"
     },
     "inputs": "Inputs",
     "modal": {
@@ -68,6 +69,7 @@
     },
     "required_files": "Required Files",
     "required_files_count": "{count} / {total} Files",
+    "hide_core_confirm": "This will hide the core from the list, hidden cores can be managed in Settings",
     "settings": "Settings",
     "sponsor": "Sponsor",
     "download_count": "Downloads",
@@ -514,6 +516,11 @@
     "logs": {
       "title": "Logs",
       "button": "Open Log Folder"
+    },
+    "hidden_cores": {
+      "title": "Hidden Cores",
+      "ramble": "These cores are hidden from the list of available uninstalled cores, if installed they are not hidden. \nYou can hide cores from their info pages.",
+      "button": "Clear hidden cores list"
     },
     "thanks": "Thanks to:"
   },

--- a/src/recoil/config/selectors.ts
+++ b/src/recoil/config/selectors.ts
@@ -21,6 +21,7 @@ export const PocketSyncConfigSelector = selector<PocketSyncConfig>({
         archive_url: null,
         saves: [],
         skipAlternateAssets: true,
+        hidden_cores: [],
       } satisfies PocketSyncConfig
     }
 
@@ -32,6 +33,7 @@ export const PocketSyncConfigSelector = selector<PocketSyncConfig>({
         archive_url: null,
         saves: [],
         skipAlternateAssets: true,
+        hidden_cores: [],
       } satisfies PocketSyncConfig
       const encoder = new TextEncoder()
       await invokeSaveFile(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,6 +236,7 @@ export type PocketSyncConfig = {
   skipAlternateAssets?: boolean
   fetches?: FetchType[]
   patreon_email?: string
+  hidden_cores?: string[]
 }
 
 export type SaveConfig = {


### PR DESCRIPTION
- Closes #350
- Provides a (reversable) manual way to do #293 so I'm going to say it closes #293 too since it's simple enough
- Also mostly fixes #314 (at least the annoying jumping bit) solution's a bit weird but I'm happy enough with it. Would prefer to fully hook into React's Transition stuff & have the old UI rendered until the new one can take its place... but that'd be a pretty big refactor (probably involving moving away from Recoil too)