### PR TITLE
Adds a warning when you've got too many display modes active

### DIFF
--- a/src/components/cores/info/displayModes/index.tsx
+++ b/src/components/cores/info/displayModes/index.tsx
@@ -9,6 +9,8 @@ import { pocketPathAtom } from "../../../../recoil/atoms"
 import { VideoJSON } from "../../../../types"
 import { invokeSaveFile } from "../../../../utils/invokes"
 import { confirm } from "@tauri-apps/plugin-dialog"
+import { WarningIcon } from "../requiredFiles/warningIcon"
+import { Tip } from "../../../tip"
 
 type DisplayModesProps = {
   coreName: string
@@ -93,6 +95,8 @@ export const DisplayModes = ({ coreName }: DisplayModesProps) => {
     [activeModes, videoJson.video, pocketPath, coreName, t]
   )
 
+  const tooManyModes = activeModes.length > 16
+
   return (
     <div className="core-info__display-modes-list">
       {Object.entries(DISPLAY_MODES).map(
@@ -107,6 +111,11 @@ export const DisplayModes = ({ coreName }: DisplayModesProps) => {
             </SupportsBubble>
           )
         }
+      )}
+      {tooManyModes && (
+        <Tip warning>
+          {t("display_modes_limit", { count: activeModes.length })}
+        </Tip>
       )}
     </div>
   )

--- a/src/components/tip/index.css
+++ b/src/components/tip/index.css
@@ -19,3 +19,13 @@
     height: 1.1em;
   }
 }
+
+.tip--warning {
+  background-color: var( --red-colour);
+  font-weight: bold;
+
+  &::before {
+    font-size: 1.25rem;
+    content: "!";
+  }
+}

--- a/src/components/tip/index.tsx
+++ b/src/components/tip/index.tsx
@@ -1,6 +1,19 @@
 import { ReactNode } from "react"
 import "./index.css"
+import { useBEM } from "../../hooks/useBEM"
 
-export const Tip = ({ children }: { children: ReactNode }) => (
-  <div className="tip">{children}</div>
-)
+type TipProps = {
+  children: ReactNode
+  warning?: boolean
+}
+
+export const Tip = ({ children, warning = false }: TipProps) => {
+  const className = useBEM({
+    block: "tip",
+    modifiers: {
+      warning: warning,
+    },
+  })
+
+  return <div className={className}>{children}</div>
+}

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -88,6 +88,7 @@
     "display_modes_title": "Display Modes",
     "display_mode_warning": "This display mode requires the core to be updated, are you sure you want to turn it on?",
     "info_txt_title": "Info.txt",
+    "display_modes_limit": "Cores only support up to 16 display modes, you have {count} selected",
     "display_modes": {
       "crt_trinitron": "CRT Trinitron",
       "grayscale_lcd": "Grayscale LCD",


### PR DESCRIPTION
- Set out to have the display modes sortable via drag & drop but there's a Tauri conflict with the zip file drops preventing that from working.