### PR TITLE
Adds support for deriving .gbp palettes from .pal ones

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -336,7 +336,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -379,7 +379,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -538,7 +538,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1111,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1121,7 +1121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1145,7 +1145,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1202,7 +1202,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1251,7 +1251,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1283,7 +1283,7 @@ checksum = "f2b99bf03862d7f545ebc28ddd33a665b50865f4dfd84031a393823879bd4c54"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1396,7 +1396,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1592,7 +1592,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2020,7 +2020,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2111,7 +2111,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2469,7 +2469,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -2794,7 +2794,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3145,7 +3145,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3250,7 +3250,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3553,7 +3553,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3791,7 +3791,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -3838,7 +3838,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4130,7 +4130,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tokio",
  "tracing",
 ]
@@ -4149,7 +4149,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4656,7 +4656,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4757,7 +4757,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4768,7 +4768,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4791,7 +4791,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -4842,7 +4842,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5123,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5149,7 +5149,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5242,7 +5242,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5307,7 +5307,7 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tokio",
  "tray-icon",
  "url",
@@ -5358,9 +5358,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "syn 2.0.89",
+ "syn 2.0.91",
  "tauri-utils",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "time",
  "url",
  "uuid",
@@ -5376,7 +5376,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -5410,7 +5410,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5427,7 +5427,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "url",
 ]
 
@@ -5448,7 +5448,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "toml 0.8.19",
  "url",
  "uuid",
@@ -5470,7 +5470,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tokio",
  "url",
  "urlpattern",
@@ -5494,7 +5494,7 @@ dependencies = [
  "swift-rs",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "time",
 ]
 
@@ -5513,7 +5513,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5543,7 +5543,7 @@ dependencies = [
  "shared_child",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "tokio",
 ]
 
@@ -5589,7 +5589,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
 ]
 
 [[package]]
@@ -5606,7 +5606,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "url",
  "windows",
 ]
@@ -5666,7 +5666,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "toml 0.8.19",
  "url",
  "urlpattern",
@@ -5735,11 +5735,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.9",
 ]
 
 [[package]]
@@ -5750,18 +5750,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5860,7 +5860,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -5992,7 +5992,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6280,7 +6280,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "wasm-bindgen-shared",
 ]
 
@@ -6314,7 +6314,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6493,7 +6493,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6598,7 +6598,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -6609,7 +6609,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7036,7 +7036,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "synstructure",
 ]
 
@@ -7079,7 +7079,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7115,7 +7115,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7135,7 +7135,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "synstructure",
 ]
 
@@ -7156,7 +7156,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7178,7 +7178,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
 ]
 
 [[package]]
@@ -7203,7 +7203,7 @@ dependencies = [
  "pbkdf2",
  "rand 0.8.5",
  "sha1",
- "thiserror 2.0.3",
+ "thiserror 2.0.9",
  "time",
  "zeroize",
  "zopfli",
@@ -7277,7 +7277,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.91",
  "zvariant_utils",
 ]
 
@@ -7291,6 +7291,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.89",
+ "syn 2.0.91",
  "winnow 0.6.20",
 ]

--- a/src-tauri/src/palettes/mod.rs
+++ b/src-tauri/src/palettes/mod.rs
@@ -1,0 +1,70 @@
+use anyhow::Result;
+use futures::StreamExt;
+use std::path::PathBuf;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+
+#[derive(Debug)]
+struct Colour {
+    red: u8,
+    green: u8,
+    blue: u8,
+}
+
+pub async fn find_all_pal_files(root: &PathBuf) -> Result<Vec<PathBuf>> {
+    let mut walker = async_walkdir::WalkDir::new(&root);
+    let mut found_files = Vec::new();
+
+    while let Some(Ok(entry)) = walker.next().await {
+        match (
+            entry.file_type().await,
+            entry.path().extension().and_then(|ext| ext.to_str()),
+        ) {
+            (Ok(f), Some("pal")) if f.is_file() => {
+                let path = entry.path();
+                found_files.push(path);
+            }
+            (_, _) => continue,
+        }
+    }
+    Ok(found_files)
+}
+
+pub async fn down_convert_pal_to_gbp(pal_file_path: &PathBuf) -> Result<()> {
+    let mut pal_file = tokio::fs::File::open(&pal_file_path).await?;
+    let mut buffer = [0u8; 12]; // 4 Colours × 3 bytes each
+    pal_file.read_exact(&mut buffer).await?;
+
+    let mut colours = Vec::new();
+    for chunk in buffer.chunks(3) {
+        let colour = Colour {
+            red: chunk[0],
+            green: chunk[1],
+            blue: chunk[2],
+        };
+        colours.push(colour);
+    }
+
+    let mut reversed_bytes = Vec::new();
+
+    // Reverse the order of colours
+    for colour in colours.into_iter().rev() {
+        reversed_bytes.extend_from_slice(&[colour.red, colour.green, colour.blue]);
+    }
+
+    // Add 4 unused bytes (e.g., 0x00)
+    reversed_bytes.extend_from_slice(&[0u8; 4]);
+
+    let mut output_path = pal_file_path.clone();
+    output_path.set_extension("gbp");
+
+    let mut output_file = tokio::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(output_path)
+        .await?;
+
+    output_file.write_all(&reversed_bytes).await?;
+    Ok(())
+}

--- a/src/components/loader/progress/index.tsx
+++ b/src/components/loader/progress/index.tsx
@@ -5,6 +5,7 @@ import "./index.css"
 import { ProgressEvent } from "../../../types"
 import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE } from "recoil"
 import { pocketPathAtom } from "../../../recoil/atoms"
+import { useProgress } from "../../../hooks/useProgress"
 
 declare module "react" {
   interface CSSProperties {
@@ -15,31 +16,17 @@ declare module "react" {
 type ProgressLoaderProps = {
   name: string
   showToken?: boolean
+  hideUntilProgress?: boolean
 }
 
 export const ProgressLoader = ({
   name,
   showToken = false,
+  hideUntilProgress = false,
 }: ProgressLoaderProps) => {
-  const [percent, setPercent] = useState(0)
+  const { message, percent, inProgress } = useProgress(name)
 
-  const [message, setMessage] = useState<null | {
-    token: string
-    param?: string
-  }>(null)
-
-  useEffect(() => {
-    const unlisten = listen<ProgressEvent>(
-      `progress-event::${name}`,
-      ({ payload }) => {
-        setPercent(payload.progress * 100)
-        if (payload.message) setMessage(payload.message)
-      }
-    )
-    return () => {
-      unlisten.then((l) => l())
-    }
-  }, [setPercent, name])
+  if (hideUntilProgress && !inProgress) return null
 
   return (
     <ProgressLoaderInner

--- a/src/components/palettes/hooks/useSavePalette.ts
+++ b/src/components/palettes/hooks/useSavePalette.ts
@@ -3,7 +3,6 @@ import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE } from "recoil"
 import { pocketPathAtom } from "../../../recoil/atoms"
 import {
   invokeConvertSinglePalFile,
-  invokeConvertSinglePalFiles,
   invokeSaveFile,
 } from "../../../utils/invokes"
 import { PocketSyncConfigSelector } from "../../../recoil/config/selectors"

--- a/src/components/palettes/hooks/useSavePalette.ts
+++ b/src/components/palettes/hooks/useSavePalette.ts
@@ -1,10 +1,18 @@
 import { Palette } from "../../../types"
 import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE } from "recoil"
 import { pocketPathAtom } from "../../../recoil/atoms"
-import { invokeSaveFile } from "../../../utils/invokes"
+import {
+  invokeConvertSinglePalFile,
+  invokeConvertSinglePalFiles,
+  invokeSaveFile,
+} from "../../../utils/invokes"
+import { PocketSyncConfigSelector } from "../../../recoil/config/selectors"
 
 export const useSavePalette = () => {
   const pocketPath = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(pocketPathAtom)
+  const config = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
+    PocketSyncConfigSelector
+  )
 
   return async (palette: Palette, name: string) => {
     const data = new Uint8Array(56)
@@ -43,6 +51,8 @@ export const useSavePalette = () => {
     data[54] = 0x47
     data[55] = 0x42
 
-    await invokeSaveFile(`${pocketPath}/Assets/gb/common/palettes${name}`, data)
+    const path = `${pocketPath}/Assets/gb/common/palettes${name}`
+    await invokeSaveFile(path, data)
+    if (config.gb_palette_convert) await invokeConvertSinglePalFile(path)
   }
 }

--- a/src/components/settings/index.css
+++ b/src/components/settings/index.css
@@ -190,3 +190,7 @@
     margin-inline-start: 5px;
   }
 }
+
+.settings__progress-bar{
+  width: 80%;
+}

--- a/src/components/settings/index.tsx
+++ b/src/components/settings/index.tsx
@@ -17,7 +17,6 @@ import { Thanks } from "./thanks"
 import { PocketColour } from "../../types"
 import {
   alwaysUseEnglishAtom,
-  githubTokenAtom,
   keepPlatformDataAtom,
   turboDownloadsAtom,
 } from "../../recoil/settings/atoms"
@@ -28,6 +27,7 @@ import { PatreonKeys } from "./patreonKeys"
 import { patreonKeyListSelector } from "../../recoil/settings/selectors"
 import { HiddenCores } from "./items/hiddenCores"
 import { GithubToken } from "./items/githubToken"
+import { GBPalettesConversion } from "./items/gbPalettes"
 
 export const Settings = () => {
   const config = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
@@ -126,6 +126,9 @@ export const Settings = () => {
               placeholder={t("patreon_keys.placeholder")}
               value={patreonEmailInput}
               onChange={({ target }) => setPatreonEmail(target.value)}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
             />
             <button
               onClick={() => {
@@ -214,6 +217,8 @@ export const Settings = () => {
             />
           </label>
         </div>
+
+        <GBPalettesConversion />
 
         <div className="settings__row">
           <h3 className="settings__row-title">{t("reconnect.title")}</h3>

--- a/src/components/settings/items/gbPalettes.tsx
+++ b/src/components/settings/items/gbPalettes.tsx
@@ -1,0 +1,48 @@
+import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE } from "recoil"
+import { PocketSyncConfigSelector } from "../../../recoil/config/selectors"
+import { useUpdateConfig } from "../hooks/useUpdateConfig"
+import { useTranslation } from "react-i18next"
+import { invokeConvertAllPalFiles } from "../../../utils/invokes"
+import { useProgress } from "../../../hooks/useProgress"
+import { ProgressLoader } from "../../loader/progress"
+
+export const GBPalettesConversion = () => {
+  const updateConfig = useUpdateConfig()
+  const { t } = useTranslation("settings")
+  const config = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
+    PocketSyncConfigSelector
+  )
+
+  const { inProgress, percent } = useProgress("downconvert_all_pal_files")
+
+  return (
+    <div className="settings__row">
+      <h3 className="settings__row-title">
+        {t("gb_palettes_conversion.title")}
+      </h3>
+      <div className="settings__ramble">
+        {t("gb_palettes_conversion.ramble")}
+      </div>
+      <label className="settings__checkbox">
+        {t("gb_palettes_conversion.checkbox")}
+        <input
+          type="checkbox"
+          checked={config.gb_palette_convert}
+          onChange={({ target }) => {
+            if (target.checked) invokeConvertAllPalFiles()
+            updateConfig("gb_palette_convert", target.checked)
+          }}
+        />
+      </label>
+      <ProgressLoader name="downconvert_all_pal_files" hideUntilProgress />
+      {inProgress && (
+        <progress
+          id="download"
+          className="settings__progress-bar"
+          max={100}
+          value={percent}
+        ></progress>
+      )}
+    </div>
+  )
+}

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -523,6 +523,11 @@
       "ramble": "These cores are hidden from the list of available uninstalled cores, if installed they are not hidden. \nYou can hide cores from their info pages.",
       "button": "Clear hidden cores list"
     },
+    "gb_palettes_conversion": {
+      "title": "GB Palettes Formats",
+      "ramble": "Duplicate the .pal files into .gbp files. Copies the 4 colours used for the background into the new .gbp files.\nToggling will create a .gbp file for every .pal file in /Assets/gb/common/palettes",
+      "checkbox": "Enable automatic .gbp files"
+    },
     "thanks": "Thanks to:"
   },
   "time_ago": {

--- a/src/recoil/config/selectors.ts
+++ b/src/recoil/config/selectors.ts
@@ -34,6 +34,7 @@ export const PocketSyncConfigSelector = selector<PocketSyncConfig>({
         saves: [],
         skipAlternateAssets: true,
         hidden_cores: [],
+        gb_palette_convert: true,
       } satisfies PocketSyncConfig
       const encoder = new TextEncoder()
       await invokeSaveFile(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -237,6 +237,7 @@ export type PocketSyncConfig = {
   fetches?: FetchType[]
   patreon_email?: string
   hidden_cores?: string[]
+  gb_palette_convert?: boolean
 }
 
 export type SaveConfig = {

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -242,3 +242,9 @@ export const invokePatreonKeys = async (
     email,
     urls: urls.map(({ url, id }) => [url, id]),
   })
+
+export const invokeConvertAllPalFiles = async () =>
+  await invoke<void>("downconvert_all_pal_files")
+
+export const invokeConvertSinglePalFile = async (path: string) =>
+  await invoke<void>("downconvert_single_pal_file", { palFilePath: path })


### PR DESCRIPTION
- Adds a setting in settings to create `.gbp` files using the background palette from the `.pal` files (which seems to be the common thing to do, though some .pal files just have a black and white background)
- Added a progress bar for it before realising it barely takes a second, maybe someone with 100s of palettes will see it.