### PR TITLE
Fixes a few things that've been annoying for a while

### DIFF
--- a/src/components/cores/index.tsx
+++ b/src/components/cores/index.tsx
@@ -47,6 +47,8 @@ export const Cores = () => {
     [setUpdateAllOpen]
   )
 
+  console.log({ searchQuery })
+
   if (selectedCore) {
     return (
       <CoreInfo

--- a/src/components/fetch/index.tsx
+++ b/src/components/fetch/index.tsx
@@ -214,8 +214,11 @@ const ArchiveOrgItem = ({
   extensions?: string[]
   onRemove: () => void
 }) => {
+  console.log({ name })
   const { installRequiredFiles, inProgress, percent, message } =
-    useInstallRequiredFiles()
+    useInstallRequiredFiles(
+      `install_archive_files-${btoa(name).replaceAll("=", "")}`
+    )
   const { t } = useTranslation("fetch")
 
   return (

--- a/src/components/games/index.tsx
+++ b/src/components/games/index.tsx
@@ -29,10 +29,6 @@ export const Games = () => {
   const [instanceJsonOpen, setInstanceJsonOpen] = useState(false)
   const { t } = useTranslation("games")
 
-  const refresh = useRecoilCallback(({ set }) => () => {
-    set(fileSystemInvalidationAtom, Date.now())
-  })
-
   const sortedList = useMemo(
     () =>
       [...coresList].sort((a, b) => {
@@ -71,9 +67,6 @@ export const Games = () => {
         </ControlsButton>
         <ControlsButton onClick={() => setInstanceJsonOpen(true)}>
           {t("controls.instance_json")}
-        </ControlsButton>
-        <ControlsButton onClick={refresh}>
-          {t("controls.refresh")}
         </ControlsButton>
         <ControlsSelect
           options={categoryList}

--- a/src/components/games/index.tsx
+++ b/src/components/games/index.tsx
@@ -51,11 +51,9 @@ export const Games = () => {
       {cleanFilesOpen && (
         <CleanFilesModal onClose={() => setCleanFilesOpen(false)} />
       )}
-
       {instanceJsonOpen && (
         <InstanceJson onClose={() => setInstanceJsonOpen(false)} />
       )}
-
       <Controls>
         <ControlsSearch
           value={searchQuery}

--- a/src/components/games/item.tsx
+++ b/src/components/games/item.tsx
@@ -14,6 +14,8 @@ import { SearchContextSelfHidingConsumer } from "../search/context"
 import { PlatformInfoSelectorFamily } from "../../recoil/platforms/selectors"
 import { DataSlotJSON } from "../../types"
 
+const NOT_REQUIRED_BUT_MAYBE_GAME_NAMES = /(^slot)/i
+
 export const CoreFolderItem = ({ coreName }: { coreName: string }) => {
   const data = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
     DataJSONSelectorFamily(coreName)
@@ -22,9 +24,11 @@ export const CoreFolderItem = ({ coreName }: { coreName: string }) => {
   const romsSlot = useMemo<DataSlotJSON | undefined>(
     () =>
       data.data.data_slots.filter(
-        ({ required, extensions }) => required && extensions
+        ({ required, name, extensions }) =>
+          (required || name?.match(NOT_REQUIRED_BUT_MAYBE_GAME_NAMES)) &&
+          extensions
       )[0],
-    [data]
+    [data, coreName]
   )
 
   const decodedParams = useMemo(

--- a/src/components/loader/progress/index.css
+++ b/src/components/loader/progress/index.css
@@ -5,6 +5,12 @@
   width: 400px;
 }
 
+@property --percent {
+  syntax: "<percentage>";
+  inherits: true;
+  initial-value: 40%;
+}
+
 .progress-loader__bar{
   width: 100%;
   height: 15px;

--- a/src/components/loader/progress/index.tsx
+++ b/src/components/loader/progress/index.tsx
@@ -54,7 +54,7 @@ export const ProgressLoaderInner = ({
     <div className="progress-loader">
       <div
         className="progress-loader__bar"
-        style={{ "--percent": `${percent.toFixed(2)}%` }}
+        style={{ "--percent": `${percent.toFixed(0)}%` }}
       ></div>
       {message && (
         <div className="progress-loader__info">

--- a/src/components/newsFeed/index.css
+++ b/src/components/newsFeed/index.css
@@ -62,6 +62,7 @@
   text-align: left;
   font-family: GamePocket;
   font-size: 18px;
+  line-break: anywhere;
 }
 
 .news-feed__item-published {

--- a/src/components/platforms/imagePacks/index.tsx
+++ b/src/components/platforms/imagePacks/index.tsx
@@ -41,7 +41,17 @@ export const ImagePacks = ({ onClose, singlePlatformId }: ImagePacksProps) => {
 
   const imagePacks = useMemo(() => {
     if (imagePacksLoadable.state !== "hasValue") return []
-    return imagePacksLoadable.contents
+
+    if (singlePlatformId) {
+      return imagePacksLoadable.contents.filter(({ image_platforms }) =>
+        image_platforms.includes(singlePlatformId)
+      )
+    }
+
+    const sorted = [...imagePacksLoadable.contents]
+    return sorted.sort(
+      (a, b) => b.image_platforms.length - a.image_platforms.length
+    )
   }, [imagePacksLoadable])
 
   const [selections, setSelections] = useState<
@@ -76,6 +86,8 @@ export const ImagePacks = ({ onClose, singlePlatformId }: ImagePacksProps) => {
       },
     [selections]
   )
+
+  console.log({ imagePacks })
 
   return (
     <Modal className="image-packs">

--- a/src/components/platforms/index.css
+++ b/src/components/platforms/index.css
@@ -61,3 +61,18 @@
   gap: 10px;
   padding: 0 20px;
 }
+
+.platform-info__image{
+  width: 100%;
+  image-rendering: pixelated;
+}
+
+.platform__info-blurb{
+  background-color: var(--info-colour);
+  padding: 10px;
+  display: flex;
+  gap: 5px;
+  flex-direction: column;
+  justify-content: flex-start;
+  flex-grow: 1;
+}

--- a/src/components/platforms/info/index.tsx
+++ b/src/components/platforms/info/index.tsx
@@ -81,13 +81,13 @@ export const PlatformInfo = ({ id, onBack }: PlatformInfoProps) => {
       <div>
         <div className="platform__image-editable">
           <img
-            className="core-info__image"
+            className="platform-info__image"
             onClick={() => setImageEditorOpen(true)}
             src={platformImage}
           />
           <div className="platform__image-edit">{t("edit")}</div>
         </div>
-        <div className="cores__info-blurb">
+        <div className="platform__info-blurb">
           <Editable
             initialValue={platform.name}
             type="freetext"

--- a/src/components/screenshots/index.tsx
+++ b/src/components/screenshots/index.tsx
@@ -1,4 +1,11 @@
-import { Suspense, useCallback, useEffect, useMemo, useState } from "react"
+import {
+  startTransition,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import {
   useRecoilState_TRANSITION_SUPPORT_UNSTABLE,
   useRecoilValue_TRANSITION_SUPPORT_UNSTABLE,
@@ -54,7 +61,7 @@ export const Screenshots = () => {
       if (newIndex < 0) newIndex = sortedScreenshots.length - 1
       if (newIndex >= sortedScreenshots.length) newIndex = 0
 
-      setSelected(sortedScreenshots[newIndex])
+      startTransition(() => setSelected(sortedScreenshots[newIndex]))
     },
     [setSelected, selected, sortedScreenshots]
   )
@@ -80,7 +87,7 @@ export const Screenshots = () => {
         ></div>
         <div
           className="screenshots__button screenshots__button--next"
-          onClick={() => changeSelectedImage(-1)}
+          onClick={() => changeSelectedImage(1)}
         ></div>
         <ScreenshotInfo
           fileName={selected}

--- a/src/components/zipInstall/groupedFiles.tsx
+++ b/src/components/zipInstall/groupedFiles.tsx
@@ -1,0 +1,207 @@
+import { useMemo } from "react"
+import { FileTreeNode } from "./types"
+import { platform } from "os"
+import { useFlattenedTree } from "./hooks"
+import { useTranslation } from "react-i18next"
+
+type ZippedCoresProps = {
+  tree: FileTreeNode[]
+  toggleFiles: (paths: string[]) => void
+  allowedFiles: string[] | null
+}
+
+type FileGroups = {
+  cores: Record<
+    string,
+    {
+      files: string[]
+      primaryPlatform: string | null
+    }
+  >
+  platforms: Record<
+    string,
+    {
+      files: string[]
+    }
+  >
+  other: {
+    files: string[]
+  }
+}
+
+export const GroupedFiles = ({
+  tree,
+  toggleFiles,
+  allowedFiles,
+}: ZippedCoresProps) => {
+  const flattenedFiles = useFlattenedTree(tree)
+  const { t } = useTranslation("zip_install")
+  const fileGroups = useMemo<FileGroups>(() => {
+    let fileGroups: FileGroups = {
+      cores: {},
+      platforms: {},
+      other: { files: [] },
+    }
+
+    flattenedFiles.forEach((f) => {
+      const { core, platform } = getCoreAndPlatform(f.full)
+
+      if (core && platform) {
+        fileGroups.cores[core] ??= { files: [], primaryPlatform: null }
+        fileGroups.cores[core].primaryPlatform = platform
+        fileGroups.cores[core].files.push(f.full)
+      } else if (core) {
+        fileGroups.cores[core] ??= { files: [], primaryPlatform: null }
+        fileGroups.cores[core].files.push(f.full)
+      } else if (platform) {
+        fileGroups.platforms[platform] ??= { files: [] }
+        fileGroups.platforms[platform].files.push(f.full)
+      } else {
+        fileGroups.other.files.push(f.full)
+      }
+    })
+
+    return fileGroups
+  }, [flattenedFiles])
+
+  const foldedFileGroups = useMemo<FileGroups>(() => {
+    // for each platform where a core's got it as it's primary platform just put it in there
+    const folded = structuredClone(fileGroups)
+
+    const platforms = Object.fromEntries(
+      Object.entries(folded.platforms).filter(([platform, { files }]) => {
+        const foundCore = Object.entries(folded.cores).find(
+          ([_core, { primaryPlatform }]) => {
+            return primaryPlatform === platform
+          }
+        )
+
+        if (foundCore) {
+          const [_, core] = foundCore
+          core.files.push(...files)
+          return false
+        }
+        return true
+      })
+    )
+
+    return { ...folded, platforms }
+  }, [flattenedFiles])
+
+  return (
+    <div>
+      {Object.keys(foldedFileGroups.cores).length > 1 && (
+        <div>
+          <div className="zip-install__cores-title">
+            {t("grouped_files.cores")}
+          </div>
+          <div className="zip-install__cores-list">
+            {Object.entries(foldedFileGroups.cores).map(
+              ([coreName, { files }]) => (
+                <FileGroupCheckbox
+                  key={coreName}
+                  name={coreName}
+                  files={files}
+                  allowedFiles={allowedFiles}
+                  toggleFiles={toggleFiles}
+                />
+              )
+            )}
+          </div>
+        </div>
+      )}
+      {Object.keys(foldedFileGroups.platforms).length > 0 && (
+        <div>
+          <div className="zip-install__cores-title">
+            {t("grouped_files.platforms")}
+          </div>
+          <div className="zip-install__cores-list">
+            {Object.entries(foldedFileGroups.platforms).map(
+              ([platformName, { files }]) => (
+                <FileGroupCheckbox
+                  key={platformName}
+                  name={platformName}
+                  files={files}
+                  allowedFiles={allowedFiles}
+                  toggleFiles={toggleFiles}
+                />
+              )
+            )}
+          </div>
+        </div>
+      )}
+      {/* Don't think this adds much & is confusing when it appears on its own */}
+      {/* {foldedFileGroups.other.files.length > 0 && (
+        <div>
+          <FileGroupCheckbox
+            name={t("grouped_files.other")}
+            files={foldedFileGroups.other.files}
+            allowedFiles={allowedFiles}
+            toggleFiles={toggleFiles}
+          />
+        </div>
+      )} */}
+    </div>
+  )
+}
+
+type FileGroupCheckboxProps = {
+  name: string
+  files: string[]
+  allowedFiles: string[] | null
+  toggleFiles: (paths: string[]) => void
+}
+
+const FileGroupCheckbox = ({
+  name,
+  files,
+  allowedFiles,
+  toggleFiles,
+}: FileGroupCheckboxProps) => {
+  const allFilesAllowed = useMemo(() => {
+    return files.every((f) => allowedFiles?.includes(f))
+  }, [toggleFiles, allowedFiles, files])
+
+  return (
+    <label className="zip-install__cores-label">
+      <input
+        className="zip-install__cores-checkbox"
+        type="checkbox"
+        checked={allFilesAllowed}
+        onChange={() => toggleFiles(files)}
+      />
+      {`${name} - ${files.length} Files`}
+    </label>
+  )
+}
+
+const ASSET_FILE_REGEX =
+  /(?:Assets|Saves)\/(?<platform>[^/]+)\/(?:common|(?<core>[^/]+))\//
+
+const CORE_FILE_REGEX = /(?:Cores|Settings|Presets)\/(?<core>[^/]+)\//
+
+const IMAGE_FILE_REGEX = /Platforms\/_images\/(?<platform>[^/]+).bin/
+const DATA_FILE_REGEX = /Platforms\/(?<platform>[^/]+).json/
+
+const getCoreAndPlatform = (
+  filePath: string
+): {
+  core: string | undefined
+  platform: string | undefined
+} => {
+  const fileMatch =
+    filePath.match(ASSET_FILE_REGEX) ||
+    filePath.match(CORE_FILE_REGEX) ||
+    filePath.match(IMAGE_FILE_REGEX) ||
+    filePath.match(DATA_FILE_REGEX)
+
+  if (fileMatch) {
+    const { core, platform } = fileMatch.groups as {
+      core: string | undefined
+      platform: string | undefined
+    }
+    return { core, platform }
+  }
+
+  return { core: undefined, platform: undefined }
+}

--- a/src/components/zipInstall/index.css
+++ b/src/components/zipInstall/index.css
@@ -84,3 +84,39 @@
   width: 100%;
   accent-color: var(--selection-colour);
 }
+
+.zip-install__cores-list {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+}
+
+.zip-install__cores-label{
+  background-color: #0f0f0f98;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid #0f0f0f98;
+  cursor: pointer;
+  opacity: 0.8;
+}
+
+.zip-install__cores-list{
+  margin-block-end: 10px;
+}
+
+.zip-install__cores-label:hover{
+  opacity: 1;
+}
+
+.zip-install__cores-checkbox{
+  display: none;
+}
+
+.zip-install__cores-label:has(.zip-install__cores-checkbox:checked) {
+  opacity: 1;
+  border: 1px solid var(--selection-colour);
+}
+
+.zip-install__cores-title{
+  margin-block-end: 5px;
+}

--- a/src/components/zipInstall/index.tsx
+++ b/src/components/zipInstall/index.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next"
 import { useEffect } from "react"
 import { emit, listen } from "@tauri-apps/api/event"
 import { confirm as TauriConfirm } from "@tauri-apps/plugin-dialog"
+import { GroupedFiles } from "./groupedFiles"
 
 export const ZipInstall = () => {
   const { installState } = useListenForZipInstall()
@@ -54,7 +55,10 @@ const ZipInstallInner = ({
   title,
 }: InstallZipEventPayload) => {
   const tree = useTree(files)
-  const { allowedFiles, toggleFile, toggleDir } = useAllowedFiles(files)
+  const { allowedFiles, toggleFile, toggleDir, toggleFiles } = useAllowedFiles(
+    files,
+    tree
+  )
   const { confirm, cancel, handleMovedFiles, setHandleMovedFiles } =
     useZipInstallButtons(allowedFiles)
 
@@ -99,6 +103,13 @@ const ZipInstallInner = ({
   return (
     <Modal>
       <h2 className="zip-install__title">{title}</h2>
+      {tree && (
+        <GroupedFiles
+          tree={tree}
+          toggleFiles={toggleFiles}
+          allowedFiles={allowedFiles}
+        />
+      )}
       <div className="zip-install__paths">
         {!tree && <p>{t("scanning")}</p>}
         {tree &&

--- a/src/components/zipInstall/types.ts
+++ b/src/components/zipInstall/types.ts
@@ -4,6 +4,7 @@ export type FileTreeNode = {
   exists: boolean
   is_dir: boolean
   children: FileTreeNode[]
+  parent: FileTreeNode | null
 }
 
 export type InstallZipEventPayload = {

--- a/src/hooks/useInstallRequiredFiles.ts
+++ b/src/hooks/useInstallRequiredFiles.ts
@@ -6,14 +6,13 @@ import { useProgress } from "./useProgress"
 import { turboDownloadsAtom } from "../recoil/settings/atoms"
 import { invokeInstallArchiveFiles } from "../utils/invokes"
 
-export const useInstallRequiredFiles = () => {
+export const useInstallRequiredFiles = (jobId = "install_archive_files") => {
   const { archive_url } = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
     PocketSyncConfigSelector
   )
 
-  const { percent, inProgress, message, remainingTime } = useProgress(
-    "install_archive_files"
-  )
+  const { percent, inProgress, message, remainingTime } = useProgress(jobId)
+  console.log({ percent })
 
   const turboDownloads =
     useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(turboDownloadsAtom)
@@ -27,7 +26,8 @@ export const useInstallRequiredFiles = () => {
       const _response = await invokeInstallArchiveFiles(
         files,
         archiveUrl,
-        turboDownloads.enabled
+        turboDownloads.enabled,
+        jobId
       )
     },
     [archive_url, turboDownloads.enabled]

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -538,6 +538,12 @@
     "confirm_title": "Uninstall Core"
   },
   "zip_install": {
+    "grouped_files": {
+      "item": "{name} - {count, number, short} Files",
+      "cores": "Multiple Cores in Zip",
+      "platforms": "Platform files",
+      "other": "Other"
+    },
     "cancel_button": "Cancel",
     "confirm_button": "Confirm",
     "remove_duplicate": "Remove duplicate existing files",

--- a/src/recoil/platforms/selectors.ts
+++ b/src/recoil/platforms/selectors.ts
@@ -218,7 +218,7 @@ export const DataPackJsonSelectorFamily = selectorFamily<
 
 export const ImagePackImageSelectorFamily = selectorFamily<
   { imageSrc: string; file: Blob } | null,
-  ImagePack & {
+  Omit<ImagePack, "image_platforms" | "data_platforms"> & {
     platformId: PlatformId
   }
 >({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -269,6 +269,8 @@ export type ImagePack = {
   owner: string
   repository: string
   variant: string
+  image_platforms: string[]
+  data_platforms: string[]
 }
 
 export type RawFeedItem = {

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -211,12 +211,14 @@ export const invokeFindRequiredFiles = async (
 export const invokeInstallArchiveFiles = async (
   files: DataSlotFile[],
   archiveUrl: string,
-  turbo: boolean
+  turbo: boolean,
+  jobId?: string
 ) =>
   await invoke<boolean>("install_archive_files", {
     files,
     archiveUrl,
     turbo,
+    jobId,
   })
 
 export const invokeSaveMultipleFiles = async (


### PR DESCRIPTION
- The "next" and "previous" buttons in the screenshot view now actually do different things instead of both being "previous"
- Image Packs are now sorted by most-populated & when looking at images for a single platform ones without that platform aren't shown
- The "fetch" part will no longer incorrectly show progress bars for things which aren't being fetched (think it sometimes deadlocks while re-checking the files though & I want to look into that...)
- If a core has multiple cores within a zip there's now UI for enabling each core individually. Note this doesn't fix it downloading them all when updating and it doesn't know which core you were intending on installing. 