### PR TITLE
Fixes issue where the items in `Fetch` could load forever

### DIFF
--- a/src/components/about/index.tsx
+++ b/src/components/about/index.tsx
@@ -71,6 +71,15 @@ export const About = () => {
       <div className="about__sponsor">
         <Suspense>
           <div className="link" onClick={() => setChangelogOpen(true)}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              height="24px"
+              viewBox="0 -960 960 960"
+              width="24px"
+              fill="currentColor"
+            >
+              <path d="M160-80v-440H80v-240h208q-5-9-6.5-19t-1.5-21q0-50 35-85t85-35q23 0 43 8.5t37 23.5q17-16 37-24t43-8q50 0 85 35t35 85q0 11-2 20.5t-6 19.5h208v240h-80v440H160Zm400-760q-17 0-28.5 11.5T520-800q0 17 11.5 28.5T560-760q17 0 28.5-11.5T600-800q0-17-11.5-28.5T560-840Zm-200 40q0 17 11.5 28.5T400-760q17 0 28.5-11.5T440-800q0-17-11.5-28.5T400-840q-17 0-28.5 11.5T360-800ZM160-680v80h280v-80H160Zm280 520v-360H240v360h200Zm80 0h200v-360H520v360Zm280-440v-80H520v80h280Z" />
+            </svg>
             {t("whats_new")}
           </div>
           <SponsorLink />

--- a/src/components/fetch/index.tsx
+++ b/src/components/fetch/index.tsx
@@ -26,6 +26,8 @@ import { useTranslation } from "react-i18next"
 import { ControlsButton } from "../controls/inputs/button"
 import { ProgressLoader, ProgressLoaderInner } from "../loader/progress"
 import { usePreventGlobalZipInstallModal } from "../../hooks/usePreventGlobalZipInstall"
+import { FetchInfoSelectorFamily } from "../../recoil/fetch/selectors"
+import { debug } from "@tauri-apps/plugin-log"
 
 type FileStatus = "complete" | "partial" | "none" | "waiting"
 
@@ -170,13 +172,10 @@ const FileSystemStatus = ({
   destination: string
   children: (status: FileStatus, files: FileCopy[]) => ReactNode
 }) => {
-  const pocketPath = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(pocketPathAtom)
-  const pocketFileInfo = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
-    PathFileInfoSelectorFamily({ path: destination })
-  )
-  const fsFileInfo = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
-    PathFileInfoSelectorFamily({ path, offPocket: true })
-  )
+  const { pocketPath, pocketFileInfo, fsFileInfo } =
+    useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
+      FetchInfoSelectorFamily({ origin: path, destination })
+    )
 
   const files: FileCopy[] = useMemo(
     () =>

--- a/src/recoil/coreSettings/selectors.ts
+++ b/src/recoil/coreSettings/selectors.ts
@@ -1,8 +1,8 @@
 import { selectorFamily } from "recoil"
 import { InteractJSON, InteractPersistJSON } from "../../types/interact"
-import { invokeWalkDirListFiles } from "../../utils/invokes"
 import { readJSONFile } from "../../utils/readJSONFile"
 import { FileWatchAtomFamily, FolderWatchAtomFamily } from "../fileSystem/atoms"
+import { WalkDirSelectorFamily } from "../selectors"
 
 const CoreInteractFileSelectorFamily = selectorFamily<InteractJSON, string>({
   key: "CoreInteractFileSelectorFamily",
@@ -32,7 +32,9 @@ export const ListPresetInteractSelectorFamily = selectorFamily<
     async ({ get }) => {
       const path = `Presets/${coreName}/Interact`
       get(FolderWatchAtomFamily(path))
-      const inputFiles = invokeWalkDirListFiles(path, ["json"])
+      const inputFiles = get(
+        WalkDirSelectorFamily({ path, extensions: ["json"] })
+      )
       return inputFiles
     },
 })

--- a/src/recoil/fetch/selectors.tsx
+++ b/src/recoil/fetch/selectors.tsx
@@ -1,0 +1,33 @@
+import { selectorFamily } from "recoil"
+import { FetchFileMetadataWithStatus } from "../../types"
+import { pocketPathAtom } from "../atoms"
+import { PathFileInfoSelectorFamily } from "../archive/selectors"
+import { debug } from "@tauri-apps/plugin-log"
+
+export const FetchInfoSelectorFamily = selectorFamily<
+  {
+    pocketPath: string
+    pocketFileInfo: FetchFileMetadataWithStatus[]
+    fsFileInfo: FetchFileMetadataWithStatus[]
+  },
+  { origin: string; destination: string }
+>({
+  key: "FetchInfoSelectorFamily",
+  get:
+    ({ origin, destination }) =>
+    ({ get }) => {
+      const pocketPath = get(pocketPathAtom) || ""
+      const pocketFileInfo = get(
+        PathFileInfoSelectorFamily({ path: destination })
+      )
+      const fsFileInfo = get(
+        PathFileInfoSelectorFamily({ path: origin, offPocket: true })
+      )
+
+      return {
+        pocketPath,
+        pocketFileInfo,
+        fsFileInfo,
+      }
+    },
+})

--- a/src/recoil/input/selectors.ts
+++ b/src/recoil/input/selectors.ts
@@ -1,8 +1,8 @@
 import { selectorFamily } from "recoil"
 import { InputJSON } from "../../types"
-import { invokeWalkDirListFiles } from "../../utils/invokes"
 import { readJSONFile } from "../../utils/readJSONFile"
 import { FileWatchAtomFamily, FolderWatchAtomFamily } from "../fileSystem/atoms"
+import { WalkDirSelectorFamily } from "../selectors"
 
 const CoreInputSelectorFamily = selectorFamily<InputJSON, string>({
   key: "CoreInputSelectorFamily",
@@ -21,10 +21,7 @@ export const ListPresetInputsSelectorFamily = selectorFamily<string[], string>({
     (coreName: string) =>
     async ({ get }) => {
       const path = `Presets/${coreName}/Input`
-      get(FolderWatchAtomFamily(path))
-      const inputFiles = invokeWalkDirListFiles(path, ["json"])
-
-      return inputFiles
+      return get(WalkDirSelectorFamily({ path, extensions: ["json"] }))
     },
 })
 

--- a/src/recoil/palettes/selectors.tsx
+++ b/src/recoil/palettes/selectors.tsx
@@ -1,23 +1,19 @@
 import { selector, selectorFamily } from "recoil"
 import { FileWatchAtomFamily, FolderWatchAtomFamily } from "../fileSystem/atoms"
-import {
-  invokeReadBinaryFile,
-  invokeWalkDirListFiles,
-} from "../../utils/invokes"
+import { invokeReadBinaryFile } from "../../utils/invokes"
 import { GithubRelease, Palette, rgb } from "../../types"
 import { fetch as TauriFetch } from "@tauri-apps/plugin-http"
 import { paletteRepoAtom } from "./atoms"
 import * as zip from "@zip.js/zip.js"
 import { error } from "@tauri-apps/plugin-log"
 import { githubHeadersSelector } from "../settings/selectors"
+import { WalkDirSelectorFamily } from "../selectors"
 
 export const palettesListSelector = selector<string[]>({
   key: "palettesListSelector",
   get: async ({ get }) => {
     const path = "Assets/gb/common/palettes"
-    get(FolderWatchAtomFamily(path))
-    const platforms = await invokeWalkDirListFiles(path, ["pal"])
-    return platforms
+    return get(WalkDirSelectorFamily({ path, extensions: ["pal"] }))
   },
 })
 

--- a/src/recoil/saveStates/selectors.ts
+++ b/src/recoil/saveStates/selectors.ts
@@ -4,18 +4,20 @@ import {
   getBinaryMetadata,
   getCartridgeBinaryMetadata,
 } from "../../utils/getBinaryMetadata"
-import {
-  invokeReadBinaryFile,
-  invokeWalkDirListFiles,
-} from "../../utils/invokes"
+import { invokeReadBinaryFile } from "../../utils/invokes"
 import { PhotoColourMapAtom } from "./atoms"
 import { FileWatchAtomFamily, FolderWatchAtomFamily } from "../fileSystem/atoms"
+import { WalkDirSelectorFamily } from "../selectors"
 
 export const AllSaveStatesSelector = selector<string[]>({
   key: "AllSaveStatesSelector",
   get: async ({ get }) => {
-    get(FolderWatchAtomFamily("Memories/Save States"))
-    const saves = await invokeWalkDirListFiles("Memories/Save States", [".sta"])
+    const saves = get(
+      WalkDirSelectorFamily({
+        path: "Memories/Save States",
+        extensions: [".sta"],
+      })
+    )
     return saves.map((f) => f.replace(/^\//g, ""))
   },
 })

--- a/src/recoil/saves/selectors.ts
+++ b/src/recoil/saves/selectors.ts
@@ -1,18 +1,19 @@
 import { selector, selectorFamily } from "recoil"
 import { SaveZipFile } from "../../types"
 import {
-  invokeWalkDirListFiles,
   invokeListBackupSaves,
   invokeListSavesInZip,
   invokeListSavesOnPocket,
 } from "../../utils/invokes"
 import { FolderWatchAtomFamily } from "../fileSystem/atoms"
+import { WalkDirSelectorFamily } from "../selectors"
 
 export const AllSavesSelector = selector<string[]>({
   key: "AllSavesSelector",
   get: async ({ get }) => {
-    get(FolderWatchAtomFamily("Saves"))
-    const saves = await invokeWalkDirListFiles(`Saves`, [".sav"])
+    const saves = get(
+      WalkDirSelectorFamily({ path: "Saves", extensions: [".sav"] })
+    )
     return saves.map((f) => f.replace(/^\//g, ""))
   },
 })

--- a/src/recoil/selectors.ts
+++ b/src/recoil/selectors.ts
@@ -13,7 +13,6 @@ import { AUTHOUR_IMAGE } from "../values"
 import { readJSONFile } from "../utils/readJSONFile"
 import { path } from "@tauri-apps/api"
 import { FileWatchAtomFamily, FolderWatchAtomFamily } from "./fileSystem/atoms"
-import { WebviewWindow } from "@tauri-apps/api/webviewWindow"
 import { getCurrentWindow, Window } from "@tauri-apps/api/window"
 
 export const DataJSONSelectorFamily = selectorFamily<DataJSON, string>({
@@ -114,11 +113,11 @@ export const AppVersionSelector = selector<string>({
 
 export const WalkDirSelectorFamily = selectorFamily<
   string[],
-  { path: string; extensions: string[]; offPocket?: boolean }
+  { path: string; extensions?: string[]; offPocket?: boolean }
 >({
   key: "WalkDirSelectorFamily",
   get:
-    ({ path, extensions, offPocket = false }) =>
+    ({ path, extensions = [], offPocket = false }) =>
     async ({ get }) => {
       get(FolderWatchAtomFamily(path))
       const files = await invokeWalkDirListFiles(path, extensions, offPocket)

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -8,6 +8,7 @@ import {
   SaveZipFile,
   Job,
 } from "../types"
+import { debug } from "@tauri-apps/plugin-log"
 
 export const invokeOpenPocket = async () => invoke<string | null>("open_pocket")
 
@@ -152,6 +153,17 @@ export const invokeFileMTime = async (filePath: string) => {
     filePath,
   })
   return mtime * 1000
+}
+
+export const invokeFilesMTime = async (filePaths: string[]) => {
+  const mtime = await invoke<(number | null)[]>("find_mtime_for_files", {
+    fullFilePaths: filePaths,
+  })
+
+  return mtime.map((mtime, index) => ({
+    path: filePaths[index],
+    mtime: mtime ? mtime * 1000 : null,
+  }))
 }
 
 export const invokeGetFirmwareVersionsList = async () => {


### PR DESCRIPTION
- It was doing 2 Tauri invokes for each file (potentially thousands in total) and if just one of them hung the whole thing would
- Now just does one for all the files, and processes the mtime in batches of 100 (seemed safer)
- Noticable speedup in just displaying it too