### PR TITLE
Improves display of cores without images

### DIFF
--- a/src/components/cores/index.css
+++ b/src/components/cores/index.css
@@ -1,5 +1,7 @@
 .cores__platform-image {
   width: 100%;
+  height: auto;
+  background-color: white;
 }
 
 .cores__info-blurb {

--- a/src/components/cores/info/index.css
+++ b/src/components/cores/info/index.css
@@ -6,7 +6,9 @@
 
 .core-info__image {
   width: 100%;
+  height: auto;
   image-rendering: pixelated;
+  background-color: white;
 }
 
 .core-info__title {

--- a/src/components/cores/info/notInstalled.tsx
+++ b/src/components/cores/info/notInstalled.tsx
@@ -78,8 +78,12 @@ export const NotInstalledCoreInfo = ({
           {!withoutTitle && (
             <h3 className="core-info__title">{inventoryItem.platform_id}</h3>
           )}
-          <img className="core-info__image" src={imageUrl} />
-
+          <img
+            className="core-info__image"
+            src={imageUrl}
+            height="165"
+            width="521"
+          />
           {inventoryItem.requires_license && (
             <>
               <div className="core-info__requires-license">

--- a/src/components/cores/item.tsx
+++ b/src/components/cores/item.tsx
@@ -122,7 +122,12 @@ export const NotInstalledCoreItem = ({
       }}
     >
       <div className="cores__item cores__item--not-installed" onClick={onClick}>
-        <img className="cores__platform-image" src={imageUrl}></img>
+        <img
+          className="cores__platform-image"
+          src={imageUrl}
+          height="165"
+          width="521"
+        ></img>
         {identifier.endsWith("_Analogizer") && (
           <div className="cores__item-analogizer">
             <AnalogizerIcon />

--- a/src/components/cores/platformImage.tsx
+++ b/src/components/cores/platformImage.tsx
@@ -13,5 +13,5 @@ export const PlatformImage = ({
   const imageSrc = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(
     PlatformImageSelectorFamily(platformId)
   )
-  return <img className={className} src={imageSrc} />
+  return <img className={className} src={imageSrc} width="521" height="165" />
 }


### PR DESCRIPTION
Before:
<img width="339" alt="Screenshot 2025-03-30 at 22 00 57" src="https://github.com/user-attachments/assets/d445c379-0c47-4fa1-8046-c60127b3da2d" />
After:
<img width="338" alt="Screenshot 2025-03-30 at 22 00 44" src="https://github.com/user-attachments/assets/4e00b710-bf8c-4212-b4f1-a5633ef1cde7" />
