### PR TITLE
Fixes empty folders being ignored during MROM install

### DIFF
--- a/src-tauri/src/install_zip/mod.rs
+++ b/src-tauri/src/install_zip/mod.rs
@@ -422,6 +422,8 @@ async fn start_zip_install_flow(
         tokio::fs::create_dir_all(destination.parent().unwrap()).await?;
         if !source.is_dir() {
             tokio::fs::copy(&source, &destination).await?;
+        } else {
+            tokio::fs::create_dir(&destination).await?;
         }
 
         FromRustPayload::InstallZipEvent {


### PR DESCRIPTION
- Fixes #431
- Going to add some nice features in for MROM support (UI for moving & renaming roms) before getting a release out