### PR TITLE
Adds UI for MROM dumps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pocket-sync",
   "private": true,
-  "version": "5.9.3",
+  "version": "5.10.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "pocket-sync"
-version = "5.9.3"
+version = "5.10.0"
 dependencies = [
  "anyhow",
  "async-walkdir",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pocket-sync"
-version = "5.9.3"
+version = "5.10.0"
 description = "A GUI tool for doing stuff with the Analogue Pocket"
 authors = ["neil-morrison44"]
 license = "AGPL-3.0"

--- a/src/components/games/index.tsx
+++ b/src/components/games/index.tsx
@@ -1,5 +1,4 @@
 import { Suspense, useMemo, useState } from "react"
-
 import { cateogryListselector } from "../../recoil/inventory/selectors"
 import { coresListSelector } from "../../recoil/selectors"
 import { Controls } from "../controls"
@@ -13,9 +12,10 @@ import { useTranslation } from "react-i18next"
 import { ControlsSearch } from "../controls/inputs/search"
 import { ControlsButton } from "../controls/inputs/button"
 import { ControlsSelect } from "../controls/inputs/select"
-
 import "../cores/index.css"
 import { useAtomValue } from "jotai"
+import { CoreConditional } from "../shared/coreConditional"
+import { MROMModal } from "./mrom"
 
 export const Games = () => {
   const coresList = useAtomValue(coresListSelector)
@@ -23,6 +23,7 @@ export const Games = () => {
   const [filterCategory, setFilterCategory] = useState<string>("All")
   const [cleanFilesOpen, setCleanFilesOpen] = useState(false)
   const [instanceJsonOpen, setInstanceJsonOpen] = useState(false)
+  const [mromOpen, setMROMOpen] = useState(false)
   const { t } = useTranslation("games")
 
   const sortedList = useMemo(
@@ -49,12 +50,18 @@ export const Games = () => {
       {instanceJsonOpen && (
         <InstanceJson onClose={() => setInstanceJsonOpen(false)} />
       )}
+      {mromOpen && <MROMModal onClose={() => setMROMOpen(false)} />}
       <Controls>
         <ControlsSearch
           value={searchQuery}
           onChange={setSearchQuery}
           placeholder={t("controls.search")}
         />
+        <CoreConditional core="NRL.MROM">
+          <ControlsButton onClick={() => setMROMOpen(true)}>
+            {t("controls.mrom")}
+          </ControlsButton>
+        </CoreConditional>
         <ControlsButton onClick={() => setCleanFilesOpen(true)}>
           {t("controls.clean_files")}
         </ControlsButton>

--- a/src/components/games/mrom/index.css
+++ b/src/components/games/mrom/index.css
@@ -1,0 +1,67 @@
+.mrom {
+  display: flex;
+  gap: 10px;
+}
+
+.mrom__items-list {
+  border-radius: 5px;
+  padding: 20px;
+  background-color: var(--info-colour);
+  flex-grow: 1;
+  overflow: auto;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: min-content min-content max-content 1fr min-content min-content;
+  grid-auto-rows: min-content;
+  list-style: none;
+  position: relative;
+  padding-top: 0;
+}
+
+.mrom__items-header{
+  grid-column: 1/-1;
+  grid-template-columns: subgrid;
+  display: grid;
+  text-align: center;
+  align-items: center;
+  padding-inline: 20px;
+  font-weight: bold;
+  position: sticky;
+  background-color: inherit;
+  top: 0;
+  z-index: 100;
+  padding-top: 10px;
+
+}
+
+.mrom__list-item {
+  border-radius: inherit;
+  grid-column: 1/-1;
+  grid-template-columns: subgrid;
+  display: grid;
+  align-items: center;
+  background-color: var(--background-colour);
+  padding: 10px;
+}
+
+.mrom__list-item-image {
+  image-rendering: pixelated;
+  transform: scale(1);
+}
+
+.mrom__list-item-platform{
+  font-family: GamePocket, sans-serif;
+  font-size: 2rem;
+  margin-inline: 10px;
+  transform: rotate(-45deg);
+}
+
+.mrom__list-item-dumped-save, .mrom__list-item-pocket-save {
+  transform: scale(2);
+  place-self: center;
+
+  &:disabled {
+    opacity: 0.1;
+    pointer-events: none;
+  }
+}

--- a/src/components/games/mrom/index.tsx
+++ b/src/components/games/mrom/index.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { pocketPathAtom } from "../../../recoil/atoms"
+import { Modal } from "../../modal"
+
+import "./index.css"
+import { useTranslation } from "react-i18next"
+import { useAtomValue } from "jotai"
+import {
+  libraryImageSelector,
+  mromDumpedROMSListSelector,
+} from "../../../recoil/games/selectors"
+import { FileCopy, MROMInfo } from "../../../types"
+import { invokeCopyFiles, invokeMoveGame } from "../../../utils/invokes"
+
+type MROMModalProps = {
+  onClose: () => void
+}
+
+type MROMInfoAndState = MROMInfo & {
+  dest: string
+  save: "none" | "dump" | "pocket"
+}
+
+export const MROMModal = ({ onClose }: MROMModalProps) => {
+  const romDumps = useAtomValue(mromDumpedROMSListSelector)
+  const [isMovingDumps, setIsMovingDumps] = useState<boolean>(false)
+  const { t } = useTranslation("mrom")
+
+  const initialDumpState = useMemo<MROMInfoAndState[]>(() => {
+    return romDumps.map((dump) => {
+      const platformMap = {
+        DMG: "gb",
+        CGB: "gbc",
+      }
+      const dest = `/Assets/${
+        platformMap[dump.platform]
+      }/common/${dump.name.replace(/(\.gbc?)/i, (m) => m.toLowerCase())}`
+      const save = dump.dumpedSave
+        ? "dump"
+        : dump.pocketSave
+        ? "pocket"
+        : "none"
+
+      return { ...dump, dest, save }
+    })
+  }, [romDumps])
+
+  const [dumps, setDumps] = useState<MROMInfoAndState[]>(initialDumpState)
+
+  useEffect(() => {
+    if (romDumps.length === 0) setDumps([])
+  }, [romDumps])
+
+  const onMoveDumps = useCallback(async () => {
+    setIsMovingDumps(true)
+
+    for (let index = 0; index < dumps.length; index++) {
+      const dump = dumps[index]
+      if (dump.save === "dump" && dump.dumpedSave) {
+        invokeCopyFiles([
+          {
+            origin: dump.dumpedSave,
+            destination: dump.path
+              .replace("Assets", "Save")
+              .replace(/\.gb|.gbc/, ".sav"),
+            exists: true,
+          },
+        ])
+      }
+      await invokeMoveGame(dump.path, dump.dest)
+    }
+    setIsMovingDumps(false)
+  }, [dumps])
+
+  return (
+    <Modal className="mrom">
+      <h2>{t("title")}</h2>
+
+      <ol className="mrom__items-list">
+        <div className="mrom__items-header">
+          <div>{t("headers.platform")}</div>
+          <div>{t("headers.library_image")}</div>
+          <div>{t("headers.name")}</div>
+          <div>{t("headers.destination")}</div>
+          <div>{t("headers.dumped_save")}</div>
+          <div>{t("headers.pocket_save")}</div>
+        </div>
+        {dumps.map((dump, index) => {
+          return (
+            <MROMItem
+              key={dump.crc32}
+              dump={dump}
+              onChange={(updatedDump) => {
+                const newDumps = [...dumps]
+                newDumps[index] = updatedDump
+                setDumps(newDumps)
+              }}
+            />
+          )
+        })}
+      </ol>
+      {!isMovingDumps && (
+        <button onClick={onMoveDumps}>{t("move_dumps")}</button>
+      )}
+      <button onClick={onClose}>{t("close_button")}</button>
+    </Modal>
+  )
+}
+
+type MROMItemProps = {
+  dump: MROMInfoAndState
+  onChange: (update: MROMInfoAndState) => void
+}
+
+const MROMItem = ({ dump, onChange }: MROMItemProps) => {
+  const { name, crc32, platform, dest, save } = dump
+  const libraryImage = useAtomValue(libraryImageSelector({ platform, crc32 }))
+
+  return (
+    <li className="mrom__list-item">
+      <div className="mrom__list-item-platform">{platform}</div>
+      <img className="mrom__list-item-image" src={libraryImage} />
+      <div className="mrom__list-item-name">{name}</div>
+      <input
+        className="mrom__list-item-dest"
+        type="text"
+        value={dest}
+        onChange={({ target }) => onChange({ ...dump, dest: target.value })}
+      />
+      <input
+        className="mrom__list-item-dumped-save"
+        type="checkbox"
+        checked={save === "dump"}
+        disabled={dump.dumpedSave === undefined}
+        onChange={({ target }) => {
+          onChange({ ...dump, save: target.checked ? "dump" : "none" })
+        }}
+      />
+      <input
+        className="mrom__list-item-pocket-save"
+        type="checkbox"
+        checked={save === "pocket"}
+        disabled={dump.pocketSave === undefined}
+        onChange={({ target }) => {
+          onChange({ ...dump, save: target.checked ? "pocket" : "none" })
+        }}
+      />
+    </li>
+  )
+}

--- a/src/components/shared/coreConditional/index.tsx
+++ b/src/components/shared/coreConditional/index.tsx
@@ -1,0 +1,16 @@
+import { useAtomValue } from "jotai"
+import { ReactNode, useMemo } from "react"
+import { coresListSelector } from "../../../recoil/selectors"
+
+type CoreConditionalProps = {
+  children: ReactNode
+  core: string
+}
+
+export const CoreConditional = ({ children, core }: CoreConditionalProps) => {
+  const coresList = useAtomValue(coresListSelector)
+  const coreIsInstalled = useMemo(() => coresList.includes(core), [coresList])
+
+  if (!coreIsInstalled) return null
+  return <>{children}</>
+}

--- a/src/i18n/locales/en/index.json
+++ b/src/i18n/locales/en/index.json
@@ -18,6 +18,19 @@
     "files_found": "{count, plural, =0 {No cleanable files} one {# cleanable file} other {# cleanable files} } found",
     "title": "Clean Files"
   },
+  "mrom": {
+    "close_button": "Close",
+    "move_dumps": "Move Dumps",
+    "title": "MROM",
+    "headers": {
+      "platform": "Platform",
+      "library_image": "Library Image",
+      "name": "Name",
+      "destination": "Destination",
+      "dumped_save": "Dumped Save",
+      "pocket_save": "Pocket Save"
+    }
+  },
   "update_all": {
     "title": "Update All",
     "heading": {
@@ -217,6 +230,7 @@
   "games": {
     "controls": {
       "category": "Category",
+      "mrom": "MROM",
       "clean_files": "Clean Files",
       "instance_json": "Instance JSON",
       "refresh": "Refresh",

--- a/src/recoil/games/selectors.ts
+++ b/src/recoil/games/selectors.ts
@@ -1,10 +1,132 @@
-import { invokeListInstancePackageableCores } from "../../utils/invokes"
+import { sep } from "@tauri-apps/api/path"
+import {
+  invokeFileExists,
+  invokeFileMetadata,
+  invokeListInstancePackageableCores,
+  invokeReadBinaryFile,
+  invokeWalkDirListFiles,
+} from "../../utils/invokes"
 import { FolderWatchAtomFamily } from "../fileSystem/atoms"
-import { atom } from "jotai"
+import { Atom, atom } from "jotai"
+import { atomFamilyDeepEqual } from "../../utils/jotai"
+import { path } from "@tauri-apps/api"
+import { MROMInfo } from "../../types"
 
 export const instancePackagerCoresListSelector = atom<Promise<string[]>>(
   async (get) => {
     get(FolderWatchAtomFamily("Cores"))
     return await invokeListInstancePackageableCores()
   }
+)
+
+export const mromDumpedROMSListSelector = atom<Promise<MROMInfo[]>>(
+  async (get) => {
+    const MROM_ROOT = "Assets/mrom/common"
+    get(FolderWatchAtomFamily(MROM_ROOT))
+    const dumps = await invokeWalkDirListFiles(MROM_ROOT, ["GB", "GBC"])
+    const results: MROMInfo[] = []
+
+    for (let index = 0; index < dumps.length; index++) {
+      const filePath = `${MROM_ROOT}${dumps[index]}`
+      const metadata = await invokeFileMetadata(filePath)
+      const [_, platform, name] = dumps[index].split(path.sep())
+
+      const dumpedSaveFilePath = filePath.replace(/\.gbc|.gb/i, ".SAV")
+      const dumpedSaveFileExists = await invokeFileExists(dumpedSaveFilePath)
+
+      const pocketSaveFilePath = filePath
+        .replace("Assets", "Saves")
+        .replace(/\.gbc|.gb/, ".sav")
+      const pocketSaveFileExists = await invokeFileExists(pocketSaveFilePath)
+
+      results.push({
+        platform: platform as "DMG" | "CGB",
+        path: filePath,
+        name,
+        crc32: metadata.crc32.toString(16),
+        dumpedSave: dumpedSaveFileExists ? dumpedSaveFilePath : undefined,
+        pocketSave: pocketSaveFileExists ? pocketSaveFilePath : undefined,
+      })
+    }
+    return results
+  }
+)
+
+const IMAGE_SELECTOR_SCRATCH_CANVAS = document.createElement("canvas")
+
+export const libraryImageSelector = atomFamilyDeepEqual<
+  { crc32: string; platform: string },
+  Atom<Promise<string>>
+>(({ crc32, platform }) =>
+  atom(async (_get) => {
+    const platformTranslate = {
+      DMG: "GB",
+      CGB: "GB",
+    } as Record<string, string>
+
+    const filePath = `System/Library/Images/${
+      platformTranslate[platform] ?? platform
+    }/${crc32}.bin`
+    const exists = await invokeFileExists(filePath)
+    const canvas = IMAGE_SELECTOR_SCRATCH_CANVAS
+    const context = canvas.getContext("2d")
+    if (!context) return ""
+
+    if (!exists) {
+      canvas.width = 140
+      canvas.height = 140
+
+      context.fillStyle = "rgb(200,200,200)"
+      context.fillRect(0, 0, canvas.width, canvas.height)
+      context.fillStyle = "rgb(235,235,235)"
+      context.fillRect(10, 10, canvas.width - 20, canvas.height - 20)
+
+      context.font = "120px GamePocket"
+      context.textAlign = "center"
+      context.textBaseline = "middle"
+      context.fillStyle = "rgb(20,20,20)"
+      context.fillText("?", canvas.width / 2, canvas.height / 2 + 10)
+    } else {
+      const file = await invokeReadBinaryFile(filePath)
+
+      const header = file.slice(0, 8)
+      const _magic = header.slice(0, 4)
+      const widthSlice = header.slice(4, 6)
+      const heightSlice = header.slice(6, 8)
+
+      const width = widthSlice[0] + (widthSlice[1] ? widthSlice[1] + 255 : 0)
+      const height =
+        heightSlice[0] + (heightSlice[1] ? heightSlice[1] + 255 : 0)
+
+      canvas.width = width
+      canvas.height = height
+      const imageSlice = file.slice(8)
+
+      let x = 0
+      let y = 0
+      const imageDataScratch = context.createImageData(1, 1)
+
+      for (let index = 0; index < imageSlice.length; index += 4) {
+        const [b, g, r, a] = imageSlice.slice(index, index + 4)
+
+        imageDataScratch.data[0] = r
+        imageDataScratch.data[1] = g
+        imageDataScratch.data[2] = b
+        imageDataScratch.data[3] = a
+        context?.putImageData(imageDataScratch, width - y - 1, x)
+
+        if (++x === height) {
+          x = 0
+          y++
+        }
+      }
+    }
+
+    const canvasBlob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve)
+    )
+
+    if (!canvasBlob) return ""
+    return URL.createObjectURL(canvasBlob)
+  })
 )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -402,3 +402,12 @@ export type PatreonKeyInfo = {
   logo: string
   link: string
 }
+
+export type MROMInfo = {
+  path: string
+  platform: "DMG" | "CGB"
+  name: string
+  crc32: string
+  dumpedSave?: string
+  pocketSave?: string
+}

--- a/src/utils/invokes.ts
+++ b/src/utils/invokes.ts
@@ -9,6 +9,7 @@ import {
   Job,
 } from "../types"
 import { debug } from "@tauri-apps/plugin-log"
+import { path } from "@tauri-apps/api"
 
 export const invokeOpenPocket = async () => invoke<string | null>("open_pocket")
 
@@ -262,3 +263,10 @@ export const invokeConvertAllPalFiles = async () =>
 
 export const invokeConvertSinglePalFile = async (path: string) =>
   await invoke<void>("downconvert_single_pal_file", { palFilePath: path })
+
+export const invokeMoveGame = async (sourcePath: string, destPath: string) => {
+  if (sourcePath.startsWith(path.sep())) sourcePath = sourcePath.substring(1)
+  if (destPath.startsWith(path.sep())) destPath = destPath.substring(1)
+
+  await invoke<void>("move_game", { sourcePath, destPath })
+}


### PR DESCRIPTION
- Suspect this might need to change a bit with ongoing MROM development, but that's fine
- Only shows up on the Games page if the MROM core is installed
- Uses the library images to show images for games that get recognised
- Tries to handle different situations with the save files, not very well tested at the moment since none of the games I have which are MROM compatible save

<img width="1392" height="1060" alt="image" src="https://github.com/user-attachments/assets/334516f3-4972-442e-ae60-cea9b46f8a62" />
(only one of those games has actually been dumped by MROM)