### PR TITLE
Remove outdated r3f-perf dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "mdast-util-gfm-autolink-literal": "2.0.0",
     "postprocessing": "^6.37.8",
     "pretty-bytes": "^7.1.0",
-    "r3f-perf": "^7.2.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-i18next": "^16.2.0",


### PR DESCRIPTION
It requires React 18, which conflicts with the required version of React in the other parts of the project.

Closes: #379