### PR TITLE
Makes the hash cache (crc32 & md5) persistent across launches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-      - name: install Rust stable
-        uses: actions-rs/toolchain@v1
+          cache: "npm"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: "src-tauri -> target"
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'
         run: |

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -21,10 +21,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-      - name: install Rust stable
-        uses: actions-rs/toolchain@v1
+          cache: "npm"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: "src-tauri -> target"
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'
         run: |

--- a/.github/workflows/test_tauri.yml
+++ b/.github/workflows/test_tauri.yml
@@ -23,10 +23,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-      - name: install Rust stable
-        uses: actions-rs/toolchain@v1
+          cache: "npm"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          toolchain: stable
+          workspaces: "src-tauri -> target"
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-latest'
         run: |

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -474,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1351,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -2643,6 +2658,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2667,6 +2691,20 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -4818,6 +4856,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "openfpga-instance-packager",
+ "postcard",
  "rayon",
  "reqwest",
  "serde",
@@ -4870,6 +4909,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 
@@ -6192,6 +6232,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "stable_deref_trait"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ extism = "1.21.0"
 thiserror = "2.0.18"
 webbrowser = "1.2.1"
 sys-locale = "0.3.2"
+postcard = { version = "1.1.3", features = ["alloc"] }
 
 [dev-dependencies]
 mockito = { version = "1.7.0", default-features = false }

--- a/src-tauri/src/commands/archive.rs
+++ b/src-tauri/src/commands/archive.rs
@@ -1,6 +1,7 @@
 use crate::{
     PocketSyncState,
     app_error::AppError,
+    hashes::HashCacheState,
     install_files::install_file,
     progress,
     required_files::{DataSlotFile, required_files_for_core},
@@ -13,6 +14,7 @@ use tauri::{Emitter, Window};
 #[tauri::command(async)]
 pub async fn find_required_files(
     state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
     core_id: &str,
     include_alts: bool,
     archive_url: &str,
@@ -38,7 +40,15 @@ pub async fn find_required_files(
     let arc_lock = state.0.file_locker.find_lock_for(&core_dir_path).await;
     let _read_lock = arc_lock.read().await;
 
-    Ok(required_files_for_core(core_id, &pocket_path, include_alts, archive_url, window).await?)
+    Ok(required_files_for_core(
+        core_id,
+        &pocket_path,
+        include_alts,
+        archive_url,
+        window,
+        hash_cache.inner(),
+    )
+    .await?)
 }
 
 #[tauri::command(async)]

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -1,0 +1,416 @@
+use std::{path::PathBuf, time::SystemTime};
+
+use crate::{
+    FileMetadata, PocketSyncState,
+    app_error::AppError,
+    clean_fs::find_dotfiles,
+    file_cache::get_file_with_cache,
+    hashes::{HashCacheState, crc32_for_file},
+    progress,
+    saves_zip::remove_leading_slash,
+    util::{find_common_path, get_mtime_timestamp},
+};
+use async_walkdir::{DirEntry, WalkDir};
+use futures::{StreamExt, stream};
+use log::{debug, error, trace};
+use tauri::{Emitter, Manager, Window};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[tauri::command(async)]
+pub async fn read_binary_file(
+    state: tauri::State<'_, PocketSyncState>,
+    path: &str,
+    app_handle: tauri::AppHandle,
+) -> Result<Vec<u8>, String> {
+    debug!("Command: read_binary_file - {path}");
+    let pocket_path = state.0.pocket_path.read().await;
+    let path = pocket_path.join(path);
+
+    let arc_lock = state.0.file_locker.find_lock_for(&path).await;
+    let _read_lock = arc_lock.read().await;
+
+    if let Ok(mut f) = if let Ok(cache_dir) = app_handle.path().app_cache_dir() {
+        get_file_with_cache(&path, &cache_dir).await
+    } else {
+        tokio::fs::File::open(&path).await
+    } {
+        let mut buffer = vec![];
+        f.read_to_end(&mut buffer)
+            .await
+            .expect(&format!("failed to read file: {:?}", path));
+
+        Ok(buffer)
+    } else {
+        Err(format!("No file found: {}", path.display()))
+    }
+}
+
+#[tauri::command(async)]
+pub async fn read_text_file(
+    state: tauri::State<'_, PocketSyncState>,
+    path: &str,
+    app_handle: tauri::AppHandle,
+) -> Result<String, ()> {
+    debug!("Command: read_text_file - {path}");
+    let pocket_path = state.0.pocket_path.read().await;
+    let path = pocket_path.join(path);
+
+    let arc_lock = state.0.file_locker.find_lock_for(&path).await;
+    let _read_lock = arc_lock.read().await;
+
+    let mut f = if let Ok(cache_dir) = app_handle.path().app_cache_dir() {
+        get_file_with_cache(&path, &cache_dir).await
+    } else {
+        tokio::fs::File::open(&path).await
+    }
+    .expect(&format!("no file found: {:?}", &path));
+
+    let mut file_contents = String::new();
+    f.read_to_string(&mut file_contents)
+        .await
+        .expect(&format!("failed to read file: {:?}", path));
+    Ok(file_contents)
+}
+
+#[tauri::command(async)]
+pub async fn file_exists(
+    state: tauri::State<'_, PocketSyncState>,
+    path: &str,
+) -> Result<bool, AppError> {
+    trace!("Command: file_exists - {path}");
+    let pocket_path = state.0.pocket_path.read().await;
+    let path = pocket_path.join(path);
+
+    let exists = tokio::fs::try_exists(&path).await?;
+    Ok(exists)
+}
+
+#[tauri::command(async)]
+pub async fn save_file(
+    path: &str,
+    buffer: Vec<u8>,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<bool, ()> {
+    debug!("Command: save_file - {path}");
+    let file_path = PathBuf::from(path);
+    let folder_path = file_path.parent().unwrap();
+    let arc_lock = state.0.file_locker.find_lock_for(&file_path).await;
+    let _write_lock = arc_lock.write().await;
+    tokio::fs::create_dir_all(&folder_path).await.unwrap();
+    let mut file = tokio::fs::File::create(file_path).await.unwrap();
+    file.write_all(&buffer).await.unwrap();
+    file.flush().await.unwrap();
+    Ok(true)
+}
+
+#[tauri::command(async)]
+pub async fn list_files(
+    path: &str,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<Vec<String>, ()> {
+    debug!("Command: list_files - {path}");
+    let pocket_path = state.0.pocket_path.read().await;
+    let dir_path = pocket_path.join(path);
+
+    let arc_lock = state.0.file_locker.find_lock_for(&dir_path).await;
+    trace!("list_files lock requested");
+    let _read_lock = arc_lock.read().await;
+    trace!("list_files lock granted");
+
+    if !tokio::fs::try_exists(&dir_path).await.unwrap() {
+        return Ok(vec![]);
+    }
+
+    let mut paths = tokio::fs::read_dir(dir_path).await.unwrap();
+    let mut results: Vec<_> = Vec::new();
+
+    while let Ok(Some(entry)) = paths.next_entry().await {
+        let file_type = entry.file_type().await.unwrap();
+        if file_type.is_file() {
+            let file_name = entry.file_name();
+            let file_name = file_name.to_str().unwrap();
+
+            if !file_name.starts_with(".") {
+                results.push(String::from(file_name))
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[tauri::command(async)]
+pub async fn list_folders(
+    path: &str,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<Vec<String>, ()> {
+    debug!("Command: list_folders - {path}");
+    let pocket_path = state.0.pocket_path.read().await;
+    let dir_path = pocket_path.join(path);
+
+    let arc_lock = state.0.file_locker.find_lock_for(&dir_path).await;
+    let _read_lock = arc_lock.read().await;
+
+    if !tokio::fs::try_exists(&dir_path).await.unwrap() {
+        return Ok(vec![]);
+    }
+
+    let mut paths = tokio::fs::read_dir(dir_path).await.unwrap();
+    let mut results: Vec<_> = Vec::new();
+
+    while let Ok(Some(entry)) = paths.next_entry().await {
+        let file_type = entry.file_type().await.unwrap();
+        if file_type.is_dir() {
+            let file_name = entry.file_name();
+            let file_name = file_name.to_str().unwrap();
+
+            if !file_name.starts_with(".") {
+                results.push(String::from(file_name))
+            }
+        }
+    }
+
+    Ok(results)
+}
+
+#[tauri::command(async)]
+pub async fn walkdir_list_files(
+    path: &str,
+    extensions: Vec<&str>,
+    off_pocket: Option<bool>,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<Vec<String>, ()> {
+    debug!("Command: walkdir_list_files - {path}");
+    let pocket_path = state.0.pocket_path.read().await;
+    let dir_path = match off_pocket {
+        Some(true) => PathBuf::from(path),
+        None | Some(false) => pocket_path.join(remove_leading_slash(path)),
+    };
+
+    let arc_lock = state.0.file_locker.find_lock_for(&dir_path).await;
+    let _read_lock = arc_lock.read().await;
+
+    if !dir_path.exists() {
+        return Ok(vec![]);
+    }
+
+    fn is_hidden(entry: &DirEntry) -> bool {
+        entry
+            .file_name()
+            .to_str()
+            .map(|s| s.starts_with("."))
+            .unwrap_or(false)
+    }
+
+    let mut walker = WalkDir::new(&dir_path);
+    let dir_path_str = &dir_path.to_str().unwrap();
+    let mut file_paths = Vec::new();
+
+    while let Some(Ok(entry)) = walker.next().await {
+        match entry.file_type().await {
+            Ok(f) => {
+                if f.is_file() && !is_hidden(&entry) {
+                    let path = entry.path();
+                    let path_str = path.to_str().unwrap();
+                    let relative_path = path_str.replace(dir_path_str, "");
+                    if extensions.is_empty() || extensions.iter().any(|ext| path_str.ends_with(ext))
+                    {
+                        file_paths.push(relative_path);
+                    }
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+
+    Ok(file_paths)
+}
+
+#[tauri::command(async)]
+pub async fn delete_files(
+    paths: Vec<&str>,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<bool, ()> {
+    debug!("Command: delete_files");
+    let pocket_path = state.0.pocket_path.read().await;
+
+    let tasks: Vec<_> = paths
+        .into_iter()
+        .filter_map(|path| {
+            let file_path = pocket_path.join(path);
+            file_path
+                .exists()
+                .then(|| tokio::fs::remove_file(file_path))
+        })
+        .collect();
+
+    futures::future::join_all(tasks).await;
+    Ok(true)
+}
+
+#[tauri::command(async)]
+pub async fn copy_files(
+    copies: Vec<(&str, &str)>,
+    window: Window,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<bool, ()> {
+    debug!("Command: copy_files");
+
+    let mut progress = progress::ProgressEmitter::new(Box::new(|event| {
+        window.emit("progress-event::copy_files", event).unwrap();
+    }));
+
+    progress.begin_work_units(copies.len());
+
+    let all_dests: Vec<PathBuf> = copies
+        .iter()
+        .map(|(_source, dest)| PathBuf::from(dest))
+        .collect();
+    let common_dir = find_common_path(&all_dests).unwrap();
+    let arc_lock = state.0.file_locker.find_lock_for(&common_dir).await;
+    let _write_lock = arc_lock.write().await;
+
+    for (origin, destination) in copies {
+        let origin = PathBuf::from(origin);
+        let destination = PathBuf::from(&destination);
+
+        if let Err(err) = match tokio::fs::create_dir_all(destination.parent().unwrap()).await {
+            Ok(_) => tokio::fs::copy(&origin, &destination).await,
+            Err(e) => Err(e),
+        } {
+            error!("{}", err);
+        } else {
+            progress.complete_work_units(1);
+            progress.set_message("file", Some(&destination.to_string_lossy()));
+        }
+    }
+
+    Ok(true)
+}
+
+#[tauri::command(async)]
+pub async fn find_cleanable_files(
+    path: &str,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<Vec<String>, String> {
+    debug!("Command: find_cleanable_files");
+    let pocket_path = state.0.pocket_path.read().await;
+    let root_path = pocket_path.join(path);
+    let files = find_dotfiles(&root_path).await.unwrap();
+
+    Ok(files)
+}
+
+#[tauri::command(async)]
+pub async fn get_folder_size(folder: PathBuf) -> Result<u128, AppError> {
+    debug!("Command: get_folder_size - {}", &folder.display());
+    let mut size = 0;
+    let mut walker = WalkDir::new(&folder);
+
+    while let Some(Ok(entry)) = walker.next().await {
+        if entry.path().is_file() {
+            if let Ok(meta) = entry.path().metadata() {
+                size += meta.len() as u128;
+            }
+        }
+    }
+
+    Ok(size)
+}
+
+#[tauri::command(async)]
+pub async fn find_mtime_for_files(
+    full_file_paths: Vec<PathBuf>,
+) -> Result<Vec<Option<u64>>, AppError> {
+    debug!("Command: find_mtime_for_files - {}", full_file_paths.len());
+    let paths_stream = stream::iter(full_file_paths);
+
+    let results = paths_stream
+        .map(|full_path| async move {
+            match get_mtime_timestamp(&full_path).await {
+                Ok(mtime) => Some(mtime),
+                Err(err) => {
+                    eprintln!("Error processing {:?}: {}", full_path, err);
+                    None // Return None for errors
+                }
+            }
+        })
+        .buffered(100)
+        .collect::<Vec<Option<u64>>>()
+        .await;
+
+    Ok(results)
+}
+
+#[tauri::command(async)]
+pub async fn save_multiple_files(
+    state: tauri::State<'_, PocketSyncState>,
+    paths: Vec<&str>,
+    data: Vec<Vec<u8>>,
+) -> Result<(), AppError> {
+    debug!("Command: save_multiple_files");
+    let pocket_path = state.0.pocket_path.read().await;
+
+    let all_paths: Vec<PathBuf> = paths.iter().map(|p| pocket_path.join(p)).collect();
+    let common_dir = find_common_path(&all_paths).unwrap();
+
+    let arc_lock = state.0.file_locker.find_lock_for(&common_dir).await;
+    let _write_lock = arc_lock.write().await;
+
+    for (file_path, file_data) in all_paths.iter().zip(data) {
+        tokio::fs::write(file_path, file_data).await?;
+    }
+
+    Ok(())
+}
+
+#[tauri::command(async)]
+pub async fn get_file_metadata_mtime_only(
+    state: tauri::State<'_, PocketSyncState>,
+    file_path: &str,
+) -> Result<u64, AppError> {
+    trace!("Command: get_file_metadata_mtime_only");
+    let pocket_path = state.0.pocket_path.read().await;
+    let full_path = pocket_path.join(file_path);
+
+    Ok(get_mtime_timestamp(&full_path).await?)
+}
+
+#[tauri::command(async)]
+pub async fn get_file_metadata(
+    state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
+    file_path: &str,
+) -> Result<FileMetadata, AppError> {
+    trace!("Command: get_file_metadata");
+    let pocket_path = state.0.pocket_path.read().await;
+    let hash_cache = hash_cache.inner();
+    let full_path = pocket_path.join(file_path);
+
+    let crc32 = crc32_for_file(&full_path, Some(hash_cache)).await?;
+
+    let metadata = tokio::fs::metadata(full_path)
+        .await
+        .and_then(|m| m.modified())?;
+
+    let timestamp = metadata
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .and_then(|d| Ok(d.as_secs()))?;
+
+    Ok(FileMetadata {
+        timestamp_secs: timestamp,
+        crc32,
+    })
+}
+
+#[tauri::command(async)]
+pub async fn create_folder_if_missing(path: &str) -> Result<bool, ()> {
+    debug!("Command: create_folder_if_missing - {path}");
+    let folder_path = PathBuf::from(path);
+    if !folder_path.exists() {
+        tokio::fs::create_dir_all(path).await.unwrap();
+        return Ok(true);
+    }
+
+    Ok(false)
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,4 +1,6 @@
 pub mod archive;
 pub mod cores;
+pub mod files;
 pub mod firmware;
 pub mod plugins;
+pub mod saves;

--- a/src-tauri/src/commands/saves.rs
+++ b/src-tauri/src/commands/saves.rs
@@ -1,0 +1,90 @@
+use log::debug;
+use std::path::PathBuf;
+
+use crate::{
+    BackupSavesResponse, PocketSyncState,
+    app_error::AppError,
+    hashes::HashCacheState,
+    saves_zip::{
+        SaveZipFile, build_save_zip, read_save_zip_list, read_saves_in_folder, read_saves_in_zip,
+        restore_save_from_zip,
+    },
+};
+
+#[tauri::command(async)]
+pub async fn backup_saves(
+    save_paths: Vec<&str>,
+    zip_path: &str,
+    max_count: usize,
+    state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
+) -> Result<bool, ()> {
+    debug!("Command: backup_saves");
+    let pocket_path = state.0.pocket_path.read().await;
+    let hash_cache = hash_cache.inner();
+    build_save_zip(&pocket_path, save_paths, zip_path, max_count, hash_cache)
+        .await
+        .unwrap();
+
+    Ok(true)
+}
+
+#[tauri::command(async)]
+pub async fn list_backup_saves(
+    backup_path: &str,
+    hash_cache: tauri::State<'_, HashCacheState>,
+) -> Result<BackupSavesResponse, AppError> {
+    debug!("Command: list_backup_saves");
+    let path = PathBuf::from(backup_path);
+    if !path.exists() {
+        return Ok(BackupSavesResponse {
+            files: vec![],
+            exists: false,
+        });
+    }
+
+    let hash_cache = hash_cache.inner();
+    let files = read_save_zip_list(&path, hash_cache).await?;
+
+    Ok(BackupSavesResponse {
+        files,
+        exists: true,
+    })
+}
+
+#[tauri::command(async)]
+pub async fn list_saves_in_zip(zip_path: &str) -> Result<Vec<SaveZipFile>, AppError> {
+    debug!("Command: list_saves_in_zip");
+    let path = PathBuf::from(zip_path);
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+
+    Ok(read_saves_in_zip(&path).await?)
+}
+
+#[tauri::command(async)]
+pub async fn list_saves_on_pocket(
+    state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
+) -> Result<Vec<SaveZipFile>, AppError> {
+    debug!("Command: list_saves_on_pocket");
+    let pocket_path = state.0.pocket_path.read().await;
+    let hash_cache = hash_cache.inner();
+    let saves_path = pocket_path.join("Saves");
+    Ok(read_saves_in_folder(&saves_path, Some(hash_cache)).await?)
+}
+
+#[tauri::command(async)]
+pub async fn restore_save(
+    zip_path: &str,
+    file_path: &str,
+    state: tauri::State<'_, PocketSyncState>,
+) -> Result<(), ()> {
+    debug!("Command: restore_save");
+    let pocket_path = state.0.pocket_path.read().await;
+    let path = PathBuf::from(zip_path);
+    restore_save_from_zip(&path, file_path, &pocket_path).await;
+
+    Ok(())
+}

--- a/src-tauri/src/files_from_zip/mod.rs
+++ b/src-tauri/src/files_from_zip/mod.rs
@@ -73,5 +73,5 @@ pub async fn md5_file_in_zip(zip_path: &PathBuf, file_name: &str) -> Result<Stri
 
     let tmp_file_path = tmp_path_clone.join(file_name);
 
-    md5_for_file(&tmp_file_path).await
+    md5_for_file(&tmp_file_path, None).await
 }

--- a/src-tauri/src/firmware.rs
+++ b/src-tauri/src/firmware.rs
@@ -4,9 +4,7 @@ use std::{path::PathBuf, time::Instant};
 use tauri::Emitter;
 use tokio::io::AsyncWriteExt;
 
-use crate::{
-    PocketSyncState, hashes::md5_for_file, progress::ProgressEvent, util::progress_download,
-};
+use crate::{hashes::md5_for_file, progress::ProgressEvent, util::progress_download};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/firmware.rs
+++ b/src-tauri/src/firmware.rs
@@ -4,7 +4,9 @@ use std::{path::PathBuf, time::Instant};
 use tauri::Emitter;
 use tokio::io::AsyncWriteExt;
 
-use crate::{hashes::md5_for_file, progress::ProgressEvent, util::progress_download};
+use crate::{
+    PocketSyncState, hashes::md5_for_file, progress::ProgressEvent, util::progress_download,
+};
 
 #[derive(Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -79,6 +81,6 @@ pub async fn download_firmware_file(
 }
 
 pub async fn verify_firmware_file(file_path: &PathBuf, md5: &str) -> Result<bool, anyhow::Error> {
-    let file_md5 = md5_for_file(file_path).await?;
+    let file_md5 = md5_for_file(file_path, None).await?;
     Ok(file_md5 == md5)
 }

--- a/src-tauri/src/hashes.rs
+++ b/src-tauri/src/hashes.rs
@@ -1,23 +1,29 @@
 use anyhow::Result;
 use md5::{Digest, Md5};
-use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, io::Read, path::PathBuf};
 use tokio::sync::RwLock;
 
 use crate::util::get_mtime_timestamp;
 
-static MD5_HASH_CACHE: Lazy<RwLock<HashMap<(PathBuf, u64), String>>> = Lazy::new(|| {
-    let m = HashMap::new();
-    RwLock::new(m)
-});
+#[derive(Default, Serialize, Deserialize, Debug)]
+pub struct HashCache {
+    pub crc32: HashMap<(PathBuf, u64), u32>,
+    pub md5: HashMap<(PathBuf, u64), String>,
+}
 
-pub async fn md5_for_file(file_path: &PathBuf) -> Result<String> {
+pub type HashCacheState = RwLock<HashCache>;
+
+pub async fn md5_for_file(
+    file_path: &PathBuf,
+    hash_cache: Option<&RwLock<HashCache>>,
+) -> Result<String> {
     let full_path = file_path.clone();
     let timestamp = get_mtime_timestamp(&full_path).await?;
 
-    {
-        let cache_guard = MD5_HASH_CACHE.read().await;
-        if let Some(hash) = cache_guard.get(&(PathBuf::from(&full_path), timestamp)) {
+    if let Some(hash_cache) = hash_cache {
+        let cache_guard = hash_cache.read().await;
+        if let Some(hash) = cache_guard.md5.get(&(PathBuf::from(&full_path), timestamp)) {
             return Ok(String::from(hash));
         }
     }
@@ -52,25 +58,28 @@ pub async fn md5_for_file(file_path: &PathBuf) -> Result<String> {
     let hash = handle.await?;
     let hexed_hash = hex::encode(hash);
 
-    {
-        let mut cache_guard = MD5_HASH_CACHE.write().await;
-        cache_guard.insert((PathBuf::from(&file_path), timestamp), hexed_hash.clone());
+    if let Some(hash_cache) = hash_cache {
+        let mut cache_guard = hash_cache.write().await;
+        cache_guard
+            .md5
+            .insert((PathBuf::from(&file_path), timestamp), hexed_hash.clone());
     }
 
     Ok(hexed_hash)
 }
 
-static CRC32_HASH_CACHE: Lazy<RwLock<HashMap<(PathBuf, u64), u32>>> = Lazy::new(|| {
-    let m = HashMap::new();
-    RwLock::new(m)
-});
-
-pub async fn crc32_for_file(file_path: &PathBuf) -> Result<u32> {
+pub async fn crc32_for_file(
+    file_path: &PathBuf,
+    hash_cache: Option<&RwLock<HashCache>>,
+) -> Result<u32> {
     let timestamp = get_mtime_timestamp(&file_path).await?;
 
-    {
-        let cache_guard = CRC32_HASH_CACHE.read().await;
-        if let Some(hash) = cache_guard.get(&(PathBuf::from(&file_path), timestamp)) {
+    if let Some(hash_cache) = hash_cache {
+        let cache_guard = hash_cache.read().await;
+        if let Some(hash) = cache_guard
+            .crc32
+            .get(&(PathBuf::from(&file_path), timestamp))
+        {
             return Ok(hash.clone());
         }
     }
@@ -105,9 +114,11 @@ pub async fn crc32_for_file(file_path: &PathBuf) -> Result<u32> {
 
     let crc32 = handle.await?;
 
-    {
-        let mut cache_guard = CRC32_HASH_CACHE.write().await;
-        cache_guard.insert((PathBuf::from(&file_path), timestamp), crc32.clone());
+    if let Some(hash_cache) = hash_cache {
+        let mut cache_guard = hash_cache.write().await;
+        cache_guard
+            .crc32
+            .insert((PathBuf::from(&file_path), timestamp), crc32.clone());
     }
 
     Ok(crc32)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,37 +3,27 @@
     windows_subsystem = "windows"
 )]
 
-use async_walkdir::{DirEntry, WalkDir};
 use checks::{check_if_folder_looks_like_pocket, connection_task};
-use clean_fs::find_dotfiles;
 use extism::CancelHandle;
-use file_cache::{clear_file_caches, get_file_with_cache};
+use file_cache::clear_file_caches;
 use file_locks::FileLocks;
-use futures::stream::{self, StreamExt};
-use hashes::crc32_for_file;
 use install_zip::start_zip_task;
 use job_id::{Job, JobState};
-use log::{LevelFilter, debug, error, trace};
+use log::{LevelFilter, debug, trace};
 use root_files::RootFile;
 use save_sync_session::start_mister_save_sync_session;
-use saves_zip::{
-    SaveZipFile, build_save_zip, read_save_zip_list, read_saves_in_folder, read_saves_in_zip,
-    remove_leading_slash, restore_save_from_zip,
-};
+use saves_zip::SaveZipFile;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::time::SystemTime;
 use std::vec;
-use tauri::{App, Emitter, Manager, RunEvent, Window};
+use tauri::{App, Emitter, Manager, RunEvent};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_log::{Target, TargetKind};
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::app_error::AppError;
 use crate::hashes::{HashCache, HashCacheState};
-use crate::util::{find_common_path, get_mtime_timestamp};
 
 mod checks;
 mod clean_fs;
@@ -64,12 +54,10 @@ struct InnerState {
     file_locker: FileLocks,
     active_plugin_handles: Mutex<HashMap<String, CancelHandle>>,
     jobs: JobState,
-    hash_cache: RwLock<HashCache>,
 }
 
 struct PocketSyncState(InnerState);
 
-// Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command(async)]
 async fn open_pocket(
     state: tauri::State<'_, PocketSyncState>,
@@ -111,381 +99,6 @@ async fn open_pocket_folder(
 }
 
 #[tauri::command(async)]
-async fn read_binary_file(
-    state: tauri::State<'_, PocketSyncState>,
-    path: &str,
-    app_handle: tauri::AppHandle,
-) -> Result<Vec<u8>, String> {
-    debug!("Command: read_binary_file - {path}");
-    let pocket_path = state.0.pocket_path.read().await;
-    let path = pocket_path.join(path);
-
-    let arc_lock = state.0.file_locker.find_lock_for(&path).await;
-    let _read_lock = arc_lock.read().await;
-
-    if let Ok(mut f) = if let Ok(cache_dir) = app_handle.path().app_cache_dir() {
-        get_file_with_cache(&path, &cache_dir).await
-    } else {
-        tokio::fs::File::open(&path).await
-    } {
-        let mut buffer = vec![];
-        f.read_to_end(&mut buffer)
-            .await
-            .expect(&format!("failed to read file: {:?}", path));
-
-        Ok(buffer)
-    } else {
-        Err(format!("No file found: {}", path.display()))
-    }
-}
-
-#[tauri::command(async)]
-async fn read_text_file(
-    state: tauri::State<'_, PocketSyncState>,
-    path: &str,
-    app_handle: tauri::AppHandle,
-) -> Result<String, ()> {
-    debug!("Command: read_text_file - {path}");
-    let pocket_path = state.0.pocket_path.read().await;
-    let path = pocket_path.join(path);
-
-    let arc_lock = state.0.file_locker.find_lock_for(&path).await;
-    let _read_lock = arc_lock.read().await;
-
-    let mut f = if let Ok(cache_dir) = app_handle.path().app_cache_dir() {
-        get_file_with_cache(&path, &cache_dir).await
-    } else {
-        tokio::fs::File::open(&path).await
-    }
-    .expect(&format!("no file found: {:?}", &path));
-
-    let mut file_contents = String::new();
-    f.read_to_string(&mut file_contents)
-        .await
-        .expect(&format!("failed to read file: {:?}", path));
-    Ok(file_contents)
-}
-
-#[tauri::command(async)]
-async fn file_exists(
-    state: tauri::State<'_, PocketSyncState>,
-    path: &str,
-) -> Result<bool, AppError> {
-    trace!("Command: file_exists - {path}");
-    let pocket_path = state.0.pocket_path.read().await;
-    let path = pocket_path.join(path);
-
-    let exists = tokio::fs::try_exists(&path).await?;
-    Ok(exists)
-}
-
-#[tauri::command(async)]
-async fn save_file(
-    path: &str,
-    buffer: Vec<u8>,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<bool, ()> {
-    debug!("Command: save_file - {path}");
-    let file_path = PathBuf::from(path);
-    let folder_path = file_path.parent().unwrap();
-    let arc_lock = state.0.file_locker.find_lock_for(&file_path).await;
-    let _write_lock = arc_lock.write().await;
-    tokio::fs::create_dir_all(&folder_path).await.unwrap();
-    let mut file = tokio::fs::File::create(file_path).await.unwrap();
-    file.write_all(&buffer).await.unwrap();
-    file.flush().await.unwrap();
-    Ok(true)
-}
-
-#[tauri::command(async)]
-async fn list_files(
-    path: &str,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<Vec<String>, ()> {
-    debug!("Command: list_files - {path}");
-    let pocket_path = state.0.pocket_path.read().await;
-    let dir_path = pocket_path.join(path);
-
-    let arc_lock = state.0.file_locker.find_lock_for(&dir_path).await;
-    trace!("list_files lock requested");
-    let _read_lock = arc_lock.read().await;
-    trace!("list_files lock granted");
-
-    if !tokio::fs::try_exists(&dir_path).await.unwrap() {
-        return Ok(vec![]);
-    }
-
-    let mut paths = tokio::fs::read_dir(dir_path).await.unwrap();
-    let mut results: Vec<_> = Vec::new();
-
-    while let Ok(Some(entry)) = paths.next_entry().await {
-        let file_type = entry.file_type().await.unwrap();
-        if file_type.is_file() {
-            let file_name = entry.file_name();
-            let file_name = file_name.to_str().unwrap();
-
-            if !file_name.starts_with(".") {
-                results.push(String::from(file_name))
-            }
-        }
-    }
-
-    Ok(results)
-}
-
-#[tauri::command(async)]
-async fn list_folders(
-    path: &str,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<Vec<String>, ()> {
-    debug!("Command: list_folders - {path}");
-    let pocket_path = state.0.pocket_path.read().await;
-    let dir_path = pocket_path.join(path);
-
-    let arc_lock = state.0.file_locker.find_lock_for(&dir_path).await;
-    let _read_lock = arc_lock.read().await;
-
-    if !tokio::fs::try_exists(&dir_path).await.unwrap() {
-        return Ok(vec![]);
-    }
-
-    let mut paths = tokio::fs::read_dir(dir_path).await.unwrap();
-    let mut results: Vec<_> = Vec::new();
-
-    while let Ok(Some(entry)) = paths.next_entry().await {
-        let file_type = entry.file_type().await.unwrap();
-        if file_type.is_dir() {
-            let file_name = entry.file_name();
-            let file_name = file_name.to_str().unwrap();
-
-            if !file_name.starts_with(".") {
-                results.push(String::from(file_name))
-            }
-        }
-    }
-
-    Ok(results)
-}
-
-#[tauri::command(async)]
-async fn walkdir_list_files(
-    path: &str,
-    extensions: Vec<&str>,
-    off_pocket: Option<bool>,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<Vec<String>, ()> {
-    debug!("Command: walkdir_list_files - {path}");
-    let pocket_path = state.0.pocket_path.read().await;
-    let dir_path = match off_pocket {
-        Some(true) => PathBuf::from(path),
-        None | Some(false) => pocket_path.join(remove_leading_slash(path)),
-    };
-
-    let arc_lock = state.0.file_locker.find_lock_for(&dir_path).await;
-    let _read_lock = arc_lock.read().await;
-
-    if !dir_path.exists() {
-        return Ok(vec![]);
-    }
-
-    fn is_hidden(entry: &DirEntry) -> bool {
-        entry
-            .file_name()
-            .to_str()
-            .map(|s| s.starts_with("."))
-            .unwrap_or(false)
-    }
-
-    let mut walker = WalkDir::new(&dir_path);
-    let dir_path_str = &dir_path.to_str().unwrap();
-    let mut file_paths = Vec::new();
-
-    while let Some(Ok(entry)) = walker.next().await {
-        match entry.file_type().await {
-            Ok(f) => {
-                if f.is_file() && !is_hidden(&entry) {
-                    let path = entry.path();
-                    let path_str = path.to_str().unwrap();
-                    let relative_path = path_str.replace(dir_path_str, "");
-                    if extensions.is_empty() || extensions.iter().any(|ext| path_str.ends_with(ext))
-                    {
-                        file_paths.push(relative_path);
-                    }
-                }
-            }
-            Err(_) => continue,
-        }
-    }
-
-    Ok(file_paths)
-}
-
-#[tauri::command(async)]
-async fn backup_saves(
-    save_paths: Vec<&str>,
-    zip_path: &str,
-    max_count: usize,
-    state: tauri::State<'_, PocketSyncState>,
-    hash_cache: tauri::State<'_, HashCacheState>,
-) -> Result<bool, ()> {
-    debug!("Command: backup_saves");
-    let pocket_path = state.0.pocket_path.read().await;
-    let hash_cache = hash_cache.inner();
-    build_save_zip(&pocket_path, save_paths, zip_path, max_count, hash_cache)
-        .await
-        .unwrap();
-
-    Ok(true)
-}
-
-#[tauri::command(async)]
-async fn list_backup_saves(
-    backup_path: &str,
-    hash_cache: tauri::State<'_, HashCacheState>,
-) -> Result<BackupSavesResponse, AppError> {
-    debug!("Command: list_backup_saves");
-    let path = PathBuf::from(backup_path);
-    if !path.exists() {
-        return Ok(BackupSavesResponse {
-            files: vec![],
-            exists: false,
-        });
-    }
-
-    let hash_cache = hash_cache.inner();
-    let files = read_save_zip_list(&path, hash_cache).await?;
-
-    Ok(BackupSavesResponse {
-        files,
-        exists: true,
-    })
-}
-
-#[tauri::command(async)]
-async fn list_saves_in_zip(zip_path: &str) -> Result<Vec<SaveZipFile>, AppError> {
-    debug!("Command: list_saves_in_zip");
-    let path = PathBuf::from(zip_path);
-    if !path.exists() {
-        return Ok(vec![]);
-    }
-
-    Ok(read_saves_in_zip(&path).await?)
-}
-
-#[tauri::command(async)]
-async fn list_saves_on_pocket(
-    state: tauri::State<'_, PocketSyncState>,
-    hash_cache: tauri::State<'_, HashCacheState>,
-) -> Result<Vec<SaveZipFile>, AppError> {
-    debug!("Command: list_saves_on_pocket");
-    let pocket_path = state.0.pocket_path.read().await;
-    let hash_cache = hash_cache.inner();
-    let saves_path = pocket_path.join("Saves");
-    Ok(read_saves_in_folder(&saves_path, Some(hash_cache)).await?)
-}
-
-#[tauri::command(async)]
-async fn restore_save(
-    zip_path: &str,
-    file_path: &str,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<(), ()> {
-    debug!("Command: restore_save");
-    let pocket_path = state.0.pocket_path.read().await;
-    let path = PathBuf::from(zip_path);
-    restore_save_from_zip(&path, file_path, &pocket_path).await;
-
-    Ok(())
-}
-
-#[tauri::command(async)]
-async fn create_folder_if_missing(path: &str) -> Result<bool, ()> {
-    debug!("Command: create_folder_if_missing - {path}");
-    let folder_path = PathBuf::from(path);
-    if !folder_path.exists() {
-        tokio::fs::create_dir_all(path).await.unwrap();
-        return Ok(true);
-    }
-
-    Ok(false)
-}
-
-#[tauri::command(async)]
-async fn delete_files(
-    paths: Vec<&str>,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<bool, ()> {
-    debug!("Command: delete_files");
-    let pocket_path = state.0.pocket_path.read().await;
-
-    let tasks: Vec<_> = paths
-        .into_iter()
-        .filter_map(|path| {
-            let file_path = pocket_path.join(path);
-            file_path
-                .exists()
-                .then(|| tokio::fs::remove_file(file_path))
-        })
-        .collect();
-
-    futures::future::join_all(tasks).await;
-    Ok(true)
-}
-
-#[tauri::command(async)]
-async fn copy_files(
-    copies: Vec<(&str, &str)>,
-    window: Window,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<bool, ()> {
-    debug!("Command: copy_files");
-
-    let mut progress = progress::ProgressEmitter::new(Box::new(|event| {
-        window.emit("progress-event::copy_files", event).unwrap();
-    }));
-
-    progress.begin_work_units(copies.len());
-
-    let all_dests: Vec<PathBuf> = copies
-        .iter()
-        .map(|(_source, dest)| PathBuf::from(dest))
-        .collect();
-    let common_dir = find_common_path(&all_dests).unwrap();
-    let arc_lock = state.0.file_locker.find_lock_for(&common_dir).await;
-    let _write_lock = arc_lock.write().await;
-
-    for (origin, destination) in copies {
-        let origin = PathBuf::from(origin);
-        let destination = PathBuf::from(&destination);
-
-        if let Err(err) = match tokio::fs::create_dir_all(destination.parent().unwrap()).await {
-            Ok(_) => tokio::fs::copy(&origin, &destination).await,
-            Err(e) => Err(e),
-        } {
-            error!("{}", err);
-        } else {
-            progress.complete_work_units(1);
-            progress.set_message("file", Some(&destination.to_string_lossy()));
-        }
-    }
-
-    Ok(true)
-}
-
-#[tauri::command(async)]
-async fn find_cleanable_files(
-    path: &str,
-    state: tauri::State<'_, PocketSyncState>,
-) -> Result<Vec<String>, String> {
-    debug!("Command: find_cleanable_files");
-    let pocket_path = state.0.pocket_path.read().await;
-    let root_path = pocket_path.join(path);
-    let files = find_dotfiles(&root_path).await.unwrap();
-
-    Ok(files)
-}
-
-#[tauri::command(async)]
 async fn get_news_feed() -> Result<Vec<news_feed::FeedItem>, String> {
     debug!("Command: get_news_feed");
     let feed = news_feed::get_feed_json().await;
@@ -504,45 +117,6 @@ async fn begin_mister_sync_session(
         Ok(success) => return Ok(success),
         Err(err) => return Err(err.to_string()),
     }
-}
-
-#[tauri::command(async)]
-async fn get_file_metadata(
-    state: tauri::State<'_, PocketSyncState>,
-    hash_cache: tauri::State<'_, HashCacheState>,
-    file_path: &str,
-) -> Result<FileMetadata, AppError> {
-    trace!("Command: get_file_metadata");
-    let pocket_path = state.0.pocket_path.read().await;
-    let hash_cache = hash_cache.inner();
-    let full_path = pocket_path.join(file_path);
-
-    let crc32 = crc32_for_file(&full_path, Some(hash_cache)).await?;
-
-    let metadata = tokio::fs::metadata(full_path)
-        .await
-        .and_then(|m| m.modified())?;
-
-    let timestamp = metadata
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .and_then(|d| Ok(d.as_secs()))?;
-
-    Ok(FileMetadata {
-        timestamp_secs: timestamp,
-        crc32,
-    })
-}
-
-#[tauri::command(async)]
-async fn get_file_metadata_mtime_only(
-    state: tauri::State<'_, PocketSyncState>,
-    file_path: &str,
-) -> Result<u64, AppError> {
-    trace!("Command: get_file_metadata_mtime_only");
-    let pocket_path = state.0.pocket_path.read().await;
-    let full_path = pocket_path.join(file_path);
-
-    Ok(get_mtime_timestamp(&full_path).await?)
 }
 
 #[tauri::command(async)]
@@ -566,28 +140,6 @@ async fn check_root_files(
     let pocket_path = state.0.pocket_path.read().await;
     let hash_cache = hash_cache.inner();
     Ok(root_files::check_root_files(&pocket_path, extensions, hash_cache).await?)
-}
-
-#[tauri::command(async)]
-async fn save_multiple_files(
-    state: tauri::State<'_, PocketSyncState>,
-    paths: Vec<&str>,
-    data: Vec<Vec<u8>>,
-) -> Result<(), AppError> {
-    debug!("Command: save_multiple_files");
-    let pocket_path = state.0.pocket_path.read().await;
-
-    let all_paths: Vec<PathBuf> = paths.iter().map(|p| pocket_path.join(p)).collect();
-    let common_dir = find_common_path(&all_paths).unwrap();
-
-    let arc_lock = state.0.file_locker.find_lock_for(&common_dir).await;
-    let _write_lock = arc_lock.write().await;
-
-    for (file_path, file_data) in all_paths.iter().zip(data) {
-        tokio::fs::write(file_path, file_data).await?;
-    }
-
-    Ok(())
 }
 
 #[tauri::command(async)]
@@ -640,45 +192,6 @@ async fn downconvert_single_pal_file(pal_file_path: String) -> Result<(), AppErr
     palettes::down_convert_pal_to_gbp(&pal_file_path).await?;
 
     Ok(())
-}
-
-#[tauri::command(async)]
-async fn find_mtime_for_files(full_file_paths: Vec<PathBuf>) -> Result<Vec<Option<u64>>, AppError> {
-    debug!("Command: find_mtime_for_files - {}", full_file_paths.len());
-    let paths_stream = stream::iter(full_file_paths);
-
-    let results = paths_stream
-        .map(|full_path| async move {
-            match get_mtime_timestamp(&full_path).await {
-                Ok(mtime) => Some(mtime),
-                Err(err) => {
-                    eprintln!("Error processing {:?}: {}", full_path, err);
-                    None // Return None for errors
-                }
-            }
-        })
-        .buffered(100)
-        .collect::<Vec<Option<u64>>>()
-        .await;
-
-    Ok(results)
-}
-
-#[tauri::command(async)]
-async fn get_folder_size(folder: PathBuf) -> Result<u128, AppError> {
-    debug!("Command: get_folder_size - {}", &folder.display());
-    let mut size = 0;
-    let mut walker = WalkDir::new(&folder);
-
-    while let Some(Ok(entry)) = walker.next().await {
-        if entry.path().is_file() {
-            if let Ok(meta) = entry.path().metadata() {
-                size += meta.len() as u128;
-            }
-        }
-    }
-
-    Ok(size)
 }
 
 #[tauri::command(async)]
@@ -766,44 +279,44 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             open_pocket,
             open_pocket_folder,
-            list_files,
-            list_folders,
-            walkdir_list_files,
-            read_binary_file,
-            read_text_file,
-            save_file,
+            commands::files::list_files,
+            commands::files::list_folders,
+            commands::files::walkdir_list_files,
+            commands::files::read_binary_file,
+            commands::files::read_text_file,
+            commands::files::save_file,
             commands::cores::uninstall_core,
             commands::archive::install_archive_files,
-            file_exists,
-            backup_saves,
-            list_backup_saves,
-            list_saves_in_zip,
-            list_saves_on_pocket,
-            restore_save,
-            create_folder_if_missing,
-            delete_files,
-            copy_files,
-            find_cleanable_files,
+            commands::files::file_exists,
+            commands::saves::backup_saves,
+            commands::saves::list_backup_saves,
+            commands::saves::list_saves_in_zip,
+            commands::saves::list_saves_on_pocket,
+            commands::saves::restore_save,
+            commands::files::create_folder_if_missing,
+            commands::files::delete_files,
+            commands::files::copy_files,
+            commands::files::find_cleanable_files,
             commands::cores::list_instance_packageable_cores,
             commands::cores::run_packager_for_core,
             get_news_feed,
             begin_mister_sync_session,
-            get_file_metadata,
-            get_file_metadata_mtime_only,
+            commands::files::get_file_metadata,
+            commands::files::get_file_metadata_mtime_only,
             commands::firmware::get_firmware_versions_list,
             commands::firmware::get_firmware_release_notes,
             commands::firmware::download_firmware,
             clear_file_cache,
             check_root_files,
             commands::archive::find_required_files,
-            save_multiple_files,
+            commands::files::save_multiple_files,
             get_active_jobs,
             stop_job,
             downconvert_all_pal_files,
             downconvert_single_pal_file,
-            find_mtime_for_files,
+            commands::files::find_mtime_for_files,
             move_game,
-            get_folder_size,
+            commands::files::get_folder_size,
             commands::plugins::run_plugin,
             commands::plugins::list_and_install_plugins,
             commands::plugins::uninstall_plugin,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,6 @@ use extism::CancelHandle;
 use file_cache::{clear_file_caches, get_file_with_cache};
 use file_locks::FileLocks;
 use futures::stream::{self, StreamExt};
-use futures_locks::RwLock;
 use hashes::crc32_for_file;
 use install_zip::start_zip_task;
 use job_id::{Job, JobState};
@@ -26,13 +25,14 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
 use std::vec;
-use tauri::{App, Emitter, Manager, Window};
+use tauri::{App, Emitter, Manager, RunEvent, Window};
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_log::{Target, TargetKind};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::app_error::AppError;
+use crate::hashes::{HashCache, HashCacheState};
 use crate::util::{find_common_path, get_mtime_timestamp};
 
 mod checks;
@@ -64,6 +64,7 @@ struct InnerState {
     file_locker: FileLocks,
     active_plugin_handles: Mutex<HashMap<String, CancelHandle>>,
     jobs: JobState,
+    hash_cache: RwLock<HashCache>,
 }
 
 struct PocketSyncState(InnerState);
@@ -325,10 +326,12 @@ async fn backup_saves(
     zip_path: &str,
     max_count: usize,
     state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
 ) -> Result<bool, ()> {
     debug!("Command: backup_saves");
     let pocket_path = state.0.pocket_path.read().await;
-    build_save_zip(&pocket_path, save_paths, zip_path, max_count)
+    let hash_cache = hash_cache.inner();
+    build_save_zip(&pocket_path, save_paths, zip_path, max_count, hash_cache)
         .await
         .unwrap();
 
@@ -336,7 +339,10 @@ async fn backup_saves(
 }
 
 #[tauri::command(async)]
-async fn list_backup_saves(backup_path: &str) -> Result<BackupSavesResponse, AppError> {
+async fn list_backup_saves(
+    backup_path: &str,
+    hash_cache: tauri::State<'_, HashCacheState>,
+) -> Result<BackupSavesResponse, AppError> {
     debug!("Command: list_backup_saves");
     let path = PathBuf::from(backup_path);
     if !path.exists() {
@@ -346,7 +352,8 @@ async fn list_backup_saves(backup_path: &str) -> Result<BackupSavesResponse, App
         });
     }
 
-    let files = read_save_zip_list(&path).await?;
+    let hash_cache = hash_cache.inner();
+    let files = read_save_zip_list(&path, hash_cache).await?;
 
     Ok(BackupSavesResponse {
         files,
@@ -368,11 +375,13 @@ async fn list_saves_in_zip(zip_path: &str) -> Result<Vec<SaveZipFile>, AppError>
 #[tauri::command(async)]
 async fn list_saves_on_pocket(
     state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
 ) -> Result<Vec<SaveZipFile>, AppError> {
     debug!("Command: list_saves_on_pocket");
     let pocket_path = state.0.pocket_path.read().await;
+    let hash_cache = hash_cache.inner();
     let saves_path = pocket_path.join("Saves");
-    Ok(read_saves_in_folder(&saves_path).await?)
+    Ok(read_saves_in_folder(&saves_path, Some(hash_cache)).await?)
 }
 
 #[tauri::command(async)]
@@ -500,13 +509,15 @@ async fn begin_mister_sync_session(
 #[tauri::command(async)]
 async fn get_file_metadata(
     state: tauri::State<'_, PocketSyncState>,
+    hash_cache: tauri::State<'_, HashCacheState>,
     file_path: &str,
 ) -> Result<FileMetadata, AppError> {
     trace!("Command: get_file_metadata");
     let pocket_path = state.0.pocket_path.read().await;
+    let hash_cache = hash_cache.inner();
     let full_path = pocket_path.join(file_path);
 
-    let crc32 = crc32_for_file(&full_path).await?;
+    let crc32 = crc32_for_file(&full_path, Some(hash_cache)).await?;
 
     let metadata = tokio::fs::metadata(full_path)
         .await
@@ -549,10 +560,12 @@ mod files_from_zip;
 async fn check_root_files(
     state: tauri::State<'_, PocketSyncState>,
     extensions: Option<Vec<&str>>,
+    hash_cache: tauri::State<'_, HashCacheState>,
 ) -> Result<Vec<RootFile>, AppError> {
     debug!("Command: check_root_files");
     let pocket_path = state.0.pocket_path.read().await;
-    Ok(root_files::check_root_files(&pocket_path, extensions).await?)
+    let hash_cache = hash_cache.inner();
+    Ok(root_files::check_root_files(&pocket_path, extensions, hash_cache).await?)
 }
 
 #[tauri::command(async)]
@@ -724,7 +737,7 @@ async fn move_game(
 }
 
 fn main() {
-    tauri::Builder::default()
+    let app = tauri::Builder::default()
         .plugin(tauri_plugin_locale::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_log::Builder::new().build())
@@ -798,10 +811,37 @@ fn main() {
         ])
         .setup(|app| {
             log_panics::init();
+
+            let cache_dir = app.path().app_cache_dir().expect("No cache dir");
+            let cache_file = cache_dir.join("hash_cache.bin");
+
+            let cache_data = if let Ok(data) = std::fs::read(&cache_file) {
+                postcard::from_bytes(&data).unwrap_or_default()
+            } else {
+                HashCache::default()
+            };
+
+            dbg!(&cache_data);
+
+            app.manage(RwLock::new(cache_data));
+
             start_tasks(app)
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application");
+
+    app.run(|app_handle, event| {
+        if let RunEvent::Exit = event {
+            let hash_cache = app_handle.state::<HashCacheState>();
+
+            let cache = hash_cache.blocking_read();
+            let cache_dir = app_handle.path().app_cache_dir().unwrap();
+            let _ = std::fs::create_dir_all(&cache_dir);
+            let cache_file = cache_dir.join("hash_cache.bin");
+            let data = postcard::to_allocvec(&*cache).unwrap();
+            let _ = std::fs::write(&cache_file, data);
+        }
+    })
 }
 
 fn start_tasks(app: &App) -> Result<(), Box<dyn std::error::Error + 'static>> {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -821,8 +821,6 @@ fn main() {
                 HashCache::default()
             };
 
-            dbg!(&cache_data);
-
             app.manage(RwLock::new(cache_data));
 
             start_tasks(app)

--- a/src-tauri/src/required_files/check_file_status.rs
+++ b/src-tauri/src/required_files/check_file_status.rs
@@ -1,18 +1,20 @@
 use super::{ArchiveInfo, DataSlotFile, archive_metadata::RawMetadataItem};
 use crate::{
-    hashes::{crc32_for_file, md5_for_file},
+    hashes::{HashCache, crc32_for_file, md5_for_file},
     progress::ProgressEmitter,
     required_files::DataSlotFileStatus,
     root_files::RootFile,
 };
 use anyhow::Result;
 use std::{collections::HashMap, path::PathBuf};
+use tokio::sync::RwLock;
 
 pub async fn check_data_file_status(
     mut data_slot_files: Vec<DataSlotFile>,
     archive_metadata: Vec<RawMetadataItem>,
     files_at_root: Vec<RootFile>,
     pocket_path: &PathBuf,
+    hash_cache: Option<&RwLock<HashCache>>,
     mut progress_emit: ProgressEmitter<'_>,
 ) -> Result<Vec<DataSlotFile>> {
     let archive_hash: HashMap<_, _> = archive_metadata
@@ -69,7 +71,7 @@ pub async fn check_data_file_status(
             },
 
             (_, true, Some(root_file)) => {
-                let placed_file_md5 = md5_for_file(&file_path).await?;
+                let placed_file_md5 = md5_for_file(&file_path, hash_cache).await?;
                 let root_file_md5 = String::from(match root_file {
                     RootFile::Zipped { md5, .. } => md5,
                     RootFile::UnZipped { md5, .. } => md5,
@@ -117,7 +119,8 @@ pub async fn check_data_file_status(
                 let RawMetadataItem {
                     name, crc32, mtime, ..
                 } = metadata_item;
-                let file_crc32 = crc32_for_file(&pocket_path.join(&data_slot_file.path)).await?;
+                let file_crc32 =
+                    crc32_for_file(&pocket_path.join(&data_slot_file.path), hash_cache).await?;
 
                 if let Some(archive_crc32) = &crc32
                     .as_ref()
@@ -279,6 +282,7 @@ mod tests {
             archive_metadata,
             vec![],
             &tmp_path,
+            None,
             ProgressEmitter::default(),
         )
         .await?;
@@ -413,6 +417,7 @@ mod tests {
             archive_metadata,
             root_files,
             &tmp_path,
+            None,
             ProgressEmitter::default(),
         )
         .await?;
@@ -498,6 +503,7 @@ mod tests {
             archive_metadata,
             root_files,
             &tmp_path,
+            None,
             ProgressEmitter::default(),
         )
         .await?;

--- a/src-tauri/src/required_files/mod.rs
+++ b/src-tauri/src/required_files/mod.rs
@@ -10,9 +10,11 @@ use log::error;
 use serde::{Deserialize, Serialize};
 use std::{cmp, path::PathBuf};
 use tauri::Emitter;
+use tokio::sync::RwLock;
 
 use crate::{
     core_json_files::{CoreDetails, core::CoreFile},
+    hashes::HashCache,
     progress,
     required_files::{
         archive_metadata::get_metadata_from_archive, core_data_slots::process_core_data,
@@ -148,6 +150,7 @@ pub async fn required_files_for_core(
     include_alts: bool,
     archive_url: &str,
     window: tauri::WebviewWindow,
+    hash_cache: &RwLock<HashCache>,
 ) -> Result<Vec<DataSlotFile>> {
     let core_details: CoreDetails =
         CoreFile::from_core_path(&pocket_path.join(format!("Cores/{}", core_id)))?.into();
@@ -166,7 +169,7 @@ pub async fn required_files_for_core(
     let (instance_files, archive_meta, files_at_root) = tokio::join!(
         find_instance_files(&assets_folder, include_alts),
         get_metadata_from_archive(archive_url),
-        check_root_files(&pocket_path, Some(vec!["rom", "bin", "key"]))
+        check_root_files(&pocket_path, Some(vec!["rom", "bin", "key"]), hash_cache)
     );
 
     progress.begin_work_units((instance_files.len() + 1) * 2);
@@ -225,6 +228,7 @@ pub async fn required_files_for_core(
                 archive_meta,
                 files_at_root,
                 pocket_path,
+                Some(hash_cache),
                 progress,
             )
             .await?;
@@ -237,6 +241,7 @@ pub async fn required_files_for_core(
                 archive_meta,
                 vec![],
                 pocket_path,
+                Some(hash_cache),
                 progress,
             )
             .await?;
@@ -249,6 +254,7 @@ pub async fn required_files_for_core(
                 vec![],
                 files_at_root,
                 pocket_path,
+                Some(hash_cache),
                 progress,
             )
             .await?;

--- a/src-tauri/src/root_files/mod.rs
+++ b/src-tauri/src/root_files/mod.rs
@@ -3,10 +3,11 @@ use std::path::PathBuf;
 use anyhow::Result;
 use log::error;
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 use crate::{
     files_from_zip::{self, crc32_file_in_zip, md5_file_in_zip},
-    hashes::{crc32_for_file, md5_for_file},
+    hashes::{HashCache, crc32_for_file, md5_for_file},
 };
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -28,6 +29,7 @@ pub enum RootFile {
 pub async fn check_root_files(
     pocket_path: &PathBuf,
     extensions: Option<Vec<&str>>,
+    hash_cache: &RwLock<HashCache>,
 ) -> Result<Vec<RootFile>> {
     let mut entries = tokio::fs::read_dir(&pocket_path.as_path()).await?;
     let mut results: Vec<RootFile> = Vec::new();
@@ -84,10 +86,10 @@ pub async fn check_root_files(
 
                         let file_name = String::from(file_name);
                         let file_path = &pocket_path.join(&file_name);
-                        let md5 = md5_for_file(&file_path).await?;
+                        let md5 = md5_for_file(&file_path, Some(hash_cache)).await?;
 
                         results.push(RootFile::UnZipped {
-                            crc32: crc32_for_file(&file_path).await?,
+                            crc32: crc32_for_file(&file_path, Some(hash_cache)).await?,
                             file_name,
                             md5,
                         });

--- a/src-tauri/src/saves_zip.rs
+++ b/src-tauri/src/saves_zip.rs
@@ -8,7 +8,6 @@ use std::{
     fs::{self, File},
     io::{Cursor, Read, Write},
     path::{Path, PathBuf},
-    sync::Arc,
     time::SystemTime,
 };
 use tempdir::TempDir;

--- a/src-tauri/src/saves_zip.rs
+++ b/src-tauri/src/saves_zip.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_walkdir::WalkDir;
-use futures::{future::join_all, StreamExt};
+use futures::{StreamExt, future::join_all};
 use log::error;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -8,12 +8,14 @@ use std::{
     fs::{self, File},
     io::{Cursor, Read, Write},
     path::{Path, PathBuf},
+    sync::Arc,
     time::SystemTime,
 };
 use tempdir::TempDir;
-use zip::{result::ZipError, write::SimpleFileOptions, DateTime};
+use tokio::sync::RwLock;
+use zip::{DateTime, result::ZipError, write::SimpleFileOptions};
 
-use crate::hashes::crc32_for_file;
+use crate::hashes::{HashCache, crc32_for_file};
 
 #[derive(Eq, PartialEq, PartialOrd, Serialize, Deserialize, Debug)]
 pub struct SaveZipFile {
@@ -81,7 +83,7 @@ pub async fn read_saves_in_zip(zip_path: &PathBuf) -> Result<Vec<SaveZipFile>> {
             .await
             .unwrap();
 
-            read_saves_in_folder(&tmp_path).await
+            read_saves_in_folder(&tmp_path, None).await
         }
         Err(ZipError::InvalidArchive(_)) => {
             tokio::fs::remove_file(&zip_path).await.unwrap();
@@ -91,7 +93,10 @@ pub async fn read_saves_in_zip(zip_path: &PathBuf) -> Result<Vec<SaveZipFile>> {
     }
 }
 
-pub async fn read_saves_in_folder(folder_path: &PathBuf) -> Result<Vec<SaveZipFile>> {
+pub async fn read_saves_in_folder(
+    folder_path: &PathBuf,
+    hash_cache: Option<&RwLock<HashCache>>,
+) -> Result<Vec<SaveZipFile>> {
     let mut walker = WalkDir::new(&folder_path);
     let mut tasks: Vec<_> = Vec::new();
 
@@ -102,19 +107,20 @@ pub async fn read_saves_in_folder(folder_path: &PathBuf) -> Result<Vec<SaveZipFi
                     let file_path = entry.path().to_owned();
                     let folder_path_clone = folder_path.clone();
 
-                    let task = tokio::spawn(async move {
+                    let task = async move {
                         let metadata = tokio::fs::metadata(&file_path).await.unwrap();
                         let last_modified = time::OffsetDateTime::from(metadata.created().unwrap());
-                        let crc32 = crc32_for_file(&file_path).await.unwrap();
+
+                        let crc32 = crc32_for_file(&file_path, hash_cache).await.unwrap();
                         let folder_path_str = folder_path_clone.to_str().unwrap();
 
                         SaveZipFile {
                             filename: String::from(file_path.to_str().unwrap())
-                                .replace(&folder_path_str, ""),
+                                .replace(folder_path_str, ""),
                             last_modified: last_modified.unix_timestamp().try_into().unwrap(),
                             crc32,
                         }
-                    });
+                    };
 
                     tasks.push(task);
                 }
@@ -123,16 +129,15 @@ pub async fn read_saves_in_folder(folder_path: &PathBuf) -> Result<Vec<SaveZipFi
         }
     }
 
-    let results: Vec<SaveZipFile> = join_all(tasks)
-        .await
-        .into_iter()
-        .filter_map(Result::ok)
-        .collect();
+    let results: Vec<SaveZipFile> = join_all(tasks).await;
 
     return Ok(results);
 }
 
-pub async fn read_save_zip_list(dir_path: &PathBuf) -> Result<Vec<SaveZipFile>> {
+pub async fn read_save_zip_list(
+    dir_path: &PathBuf,
+    hash_cache: &RwLock<HashCache>,
+) -> Result<Vec<SaveZipFile>> {
     if !dir_path.exists() {
         return Ok(vec![]);
     }
@@ -149,7 +154,9 @@ pub async fn read_save_zip_list(dir_path: &PathBuf) -> Result<Vec<SaveZipFile>> 
         let metadata = file_path.metadata().unwrap();
         let last_modified = time::OffsetDateTime::from(metadata.modified().unwrap());
 
-        let crc32 = crc32_for_file(&file_path.into()).await.unwrap();
+        let crc32 = crc32_for_file(&file_path.into(), Some(hash_cache))
+            .await
+            .unwrap();
 
         results.push(SaveZipFile {
             filename: file_name,
@@ -166,6 +173,7 @@ pub async fn build_save_zip(
     save_paths: Vec<&str>,
     dir_path: &str,
     max_count: usize,
+    hash_cache: &RwLock<HashCache>,
 ) -> Result<()> {
     let zip_path = Path::new(dir_path);
     let timestamp = SystemTime::now()
@@ -217,12 +225,18 @@ pub async fn build_save_zip(
     }
     zip.finish().unwrap();
 
-    prune_zips(&zip_path, max_count).await.unwrap();
+    prune_zips(&zip_path, max_count, hash_cache).await.unwrap();
     Ok(())
 }
 
-async fn prune_zips(zip_path: &Path, max_count: usize) -> Result<()> {
-    let mut files = read_save_zip_list(&PathBuf::from(zip_path)).await.unwrap();
+async fn prune_zips(
+    zip_path: &Path,
+    max_count: usize,
+    hash_cache: &RwLock<HashCache>,
+) -> Result<()> {
+    let mut files = read_save_zip_list(&PathBuf::from(zip_path), hash_cache)
+        .await
+        .unwrap();
     files.sort();
     let last_two: Vec<&SaveZipFile> = files.iter().rev().take(2).collect();
     if last_two.len() == 2 {
@@ -232,7 +246,9 @@ async fn prune_zips(zip_path: &Path, max_count: usize) -> Result<()> {
         }
     }
 
-    let files = read_save_zip_list(&PathBuf::from(zip_path)).await.unwrap();
+    let files = read_save_zip_list(&PathBuf::from(zip_path), hash_cache)
+        .await
+        .unwrap();
     if files.len() > max_count {
         if let Some(oldest_file) = files.iter().min() {
             let last_file_path = zip_path.join(&oldest_file.filename);

--- a/src/components/games/item.tsx
+++ b/src/components/games/item.tsx
@@ -39,13 +39,18 @@ export const CoreFolderItem = ({ coreName }: { coreName: string }) => {
   const platformId = core.metadata.platform_ids[decodedParams.platformIndex]
   const { platform } = useAtomValue(PlatformInfoSelectorFamily(platformId))
 
+  const platformPath = useMemo(() => {
+    if (!romsSlot) return ""
+    return `${pocketPath}/Assets/${platformId}`
+  }, [romsSlot, pocketPath, platformId])
+
   const path = useMemo(() => {
     if (!romsSlot) return ""
     const coreSpecific = decodedParams?.coreSpecific
     return `${pocketPath}/Assets/${platformId}/${
       coreSpecific ? coreName : "common"
     }`
-  }, [romsSlot, decodedParams?.coreSpecific, pocketPath, platformId, coreName])
+  }, [romsSlot, decodedParams?.coreSpecific, platformPath, coreName])
 
   const onOpenFolder = useCallback(async (path: string) => {
     await invokeCreateFolderIfMissing(path)
@@ -81,7 +86,7 @@ export const CoreFolderItem = ({ coreName }: { coreName: string }) => {
               extensions={romsSlot?.extensions || []}
             />
             <Suspense>
-              <FolderSize path={path} />
+              <FolderSize path={platformPath} />
             </Suspense>
           </div>
           {(romsSlot?.extensions || []).map((e) => `.${e}`).join(", ")}


### PR DESCRIPTION
- Should make the app much faster at checking installed files even when reopened
- Does change saves to no longer be threaded since I'd need to do Arc stuff or a Send-able HashMap... I don't notice much change in performance
- Also changes what folder is used for the size shown in Games to be the platform one rather than the core's one, which is sort of cheating but will likely be more correct more often